### PR TITLE
ci: align PyPI publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      packages: write
 
     # Only publish on valid version tags
     if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
@@ -51,6 +50,4 @@ jobs:
         run: uv run --no-sync --frozen twine check dist/*
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Why
The PyPI **trusted publisher** for `patchsim` was just configured (owner `dsih-artpark`, repo `patchsim`, workflow `pypi-release.yml`, environment `pypi`). Two things in the repo prevented a release from actually publishing:

1. **Filename mismatch** — the workflow file was `publish.yml`, but the trusted publisher matches on the exact filename `pypi-release.yml`. OIDC auth would have failed.
2. **Token-based publish** — the publish step passed `password: ${{ secrets.PYPI_API_TOKEN }}`, but no such secret exists (no repo or `pypi`-env secrets). With trusted publishing we must omit the password so the action uses OIDC.

## Changes
- Rename `.github/workflows/publish.yml` → `.github/workflows/pypi-release.yml`.
- Remove the `password:` from the publish step → action uses Trusted Publishing (OIDC) via the existing `id-token: write` permission.
- Drop the unused `packages: write` permission (not needed for PyPI).

## After merge
Cut the first release by publishing a GitHub Release with tag `v0.1.0b1` (version is already set in `pyproject.toml`). The `release: published` event fires the workflow, which builds, tests, and publishes to PyPI via OIDC.

Note: `0.1.0b1` is a pre-release, so installs need `pip install --pre patchsim` (or `patchsim==0.1.0b1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyPI release workflow configuration to use modern authentication methods and latest action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->