### PR TITLE
fix: evaluate rate expressions safely and fix discrete solver stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Security
+- Transition rate expressions are now parsed and evaluated against an arithmetic-only
+  allowlist instead of `eval`. Expressions come from user-supplied YAML, and configs are
+  shared as self-contained project directories, so a config could previously execute
+  arbitrary code when a simulation was run.
+
+### Fixed
+- Rate expressions that overflow, divide by zero, or produce a complex value are now
+  rejected instead of returning `inf` or a complex number into the simulation.
+- Rate expressions accept numpy scalars of any dtype; previously only `float64` worked,
+  because it is the one numpy type that subclasses Python's `float`.
+
+### Changed
+- **Breaking:** `NetworkModel.simulate_discrete()` now takes one Euler step per interval
+  in `t_range`, using that interval's own width, and raises on divergence rather than
+  returning negative populations. It previously assumed unit spacing regardless of the
+  grid supplied, so any caller passing a non-unit `t_range` received silently incorrect
+  results and will now see different values. Time grids must be finite and strictly
+  increasing; unevenly spaced grids are supported.
+
 ## 0.1.0b1 - 2026-04-08
 
 ### Added

--- a/src/patchsim/core/expressions.py
+++ b/src/patchsim/core/expressions.py
@@ -8,6 +8,7 @@ import ast
 import math
 import numbers
 import operator
+from functools import lru_cache
 from typing import Any, Mapping
 
 _MAX_DEPTH = 64  # maximum expression nesting depth
@@ -29,6 +30,21 @@ _UNARY_OPS = {
 }
 
 
+@lru_cache(maxsize=256)
+def _parse(expression: str) -> ast.AST:
+    if len(expression) > _MAX_LENGTH:
+        raise ValueError(f"is too long to evaluate ({len(expression)} characters, limit {_MAX_LENGTH})")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"could not be parsed: {exc.msg}") from exc
+    except (RecursionError, MemoryError) as exc:
+        raise ValueError("is too deeply nested to parse") from exc
+
+    return tree.body
+
+
 def evaluate(expression: str, scope: Mapping[str, Any]) -> float:
     """Evaluate an arithmetic rate expression against a scope of named values.
 
@@ -43,17 +59,7 @@ def evaluate(expression: str, scope: Mapping[str, Any]) -> float:
         ValueError: If the expression uses an unsupported construct, references an
             unknown name, or cannot be evaluated numerically.
     """
-    if len(expression) > _MAX_LENGTH:
-        raise ValueError(f"is too long to evaluate ({len(expression)} characters, limit {_MAX_LENGTH})")
-
-    try:
-        tree = ast.parse(expression, mode="eval")
-    except SyntaxError as exc:
-        raise ValueError(f"could not be parsed: {exc.msg}") from exc
-    except (RecursionError, MemoryError) as exc:
-        raise ValueError("is too deeply nested to parse") from exc
-
-    return _evaluate_node(tree.body, scope, depth=0)
+    return _evaluate_node(_parse(expression), scope, depth=0)
 
 
 def _evaluate_node(node: ast.AST, scope: Mapping[str, Any], depth: int) -> float:

--- a/src/patchsim/core/expressions.py
+++ b/src/patchsim/core/expressions.py
@@ -1,0 +1,140 @@
+"""Evaluate transition rate expressions from user config files.
+
+Evaluation is restricted to arithmetic over named values so that a config file cannot
+execute arbitrary code. Any other construct is rejected.
+"""
+
+import ast
+import math
+import numbers
+import operator
+from typing import Any, Mapping
+
+_MAX_DEPTH = 64  # maximum expression nesting depth
+_MAX_LENGTH = 1000  # maximum expression length in characters
+
+_BINARY_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+
+_UNARY_OPS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+
+def evaluate(expression: str, scope: Mapping[str, Any]) -> float:
+    """Evaluate an arithmetic rate expression against a scope of named values.
+
+    Args:
+        expression: Arithmetic expression over parameter and compartment names.
+        scope: Mapping of names available to the expression.
+
+    Returns:
+        The numeric value of the expression.
+
+    Raises:
+        ValueError: If the expression uses an unsupported construct, references an
+            unknown name, or cannot be evaluated numerically.
+    """
+    if len(expression) > _MAX_LENGTH:
+        raise ValueError(f"is too long to evaluate ({len(expression)} characters, limit {_MAX_LENGTH})")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"could not be parsed: {exc.msg}") from exc
+    except (RecursionError, MemoryError) as exc:
+        raise ValueError("is too deeply nested to parse") from exc
+
+    return _evaluate_node(tree.body, scope, depth=0)
+
+
+def _evaluate_node(node: ast.AST, scope: Mapping[str, Any], depth: int) -> float:
+    if depth > _MAX_DEPTH:
+        raise ValueError(f"is too deeply nested to evaluate (limit {_MAX_DEPTH} levels)")
+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, numbers.Real):
+            raise ValueError(f"{type(node.value).__name__} literals are not allowed in rate expressions")
+        return _coerce(node.value, "a numeric literal")
+
+    if isinstance(node, ast.Name):
+        if node.id not in scope:
+            raise ValueError(f"unknown name '{node.id}'; expected a parameter or compartment")
+        return _coerce(scope[node.id], f"name '{node.id}'")
+
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINARY_OPS:
+        left = _evaluate_node(node.left, scope, depth + 1)
+        right = _evaluate_node(node.right, scope, depth + 1)
+        return _apply(_BINARY_OPS[type(node.op)], left, right)
+
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARY_OPS:
+        return _apply(_UNARY_OPS[type(node.op)], _evaluate_node(node.operand, scope, depth + 1))
+
+    raise ValueError(
+        f"{_describe(node)} is not allowed in rate expressions, "
+        "which may only combine parameters and compartments arithmetically"
+    )
+
+
+def _coerce(value: Any, description: str) -> float:
+    """Convert a value to a finite real float, or raise ValueError.
+
+    Accepts ``numbers.Real`` rather than ``float`` because solver state can be a numpy
+    scalar and only ``numpy.float64`` subclasses ``float``. Complex results (from a
+    negative base to a fractional power) and non-finite results (from overflow) are
+    rejected.
+    """
+    if isinstance(value, complex):
+        raise ValueError(f"{description} is a complex number; rates must be real")
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise ValueError(f"{description} is not a real number")
+    try:
+        result = float(value)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{description} is too large to represent as a floating point number") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"{description} is {result}; rates must be finite")
+    return result
+
+
+def _apply(op, *operands: float) -> float:
+    """Apply an arithmetic operator and validate its result."""
+    try:
+        value = op(*operands)
+    except ZeroDivisionError as exc:
+        raise ValueError("attempted division by zero") from exc
+    except OverflowError as exc:
+        raise ValueError("overflowed to a value that is not finite") from exc
+    except ValueError as exc:
+        raise ValueError(f"could not be evaluated: {exc}") from exc
+
+    return _coerce(value, "the expression")
+
+
+def _describe(node: ast.AST) -> str:
+    """Return a readable name for a disallowed construct, for the error message."""
+    descriptions = {
+        ast.Attribute: "attribute access",
+        ast.Call: "function calls",
+        ast.Subscript: "indexing",
+        ast.ListComp: "comprehensions",
+        ast.GeneratorExp: "comprehensions",
+        ast.DictComp: "comprehensions",
+        ast.SetComp: "comprehensions",
+        ast.Lambda: "lambdas",
+        ast.List: "list literals",
+        ast.Tuple: "tuple literals",
+        ast.Dict: "dict literals",
+    }
+    for node_type, description in descriptions.items():
+        if isinstance(node, node_type):
+            return description
+    return f"{type(node).__name__} expressions"

--- a/src/patchsim/core/model.py
+++ b/src/patchsim/core/model.py
@@ -5,7 +5,67 @@ Core model implementation for compartmental models.
 import re
 from typing import Any, Callable, Dict
 
+import numpy as np
 from scipy.integrate import odeint
+
+from patchsim.core.expressions import evaluate as evaluate_expression
+
+# Negative values within this fraction of the initial population are treated as rounding error.
+_NEGATIVITY_TOLERANCE = 1e-9
+_MAX_EXPRESSION_IN_ERROR = 80  # max expression length shown in error messages
+
+
+def _validated_time_grid(t_range: list[float]) -> "np.ndarray":
+    """Return ``t_range`` as a finite, strictly increasing 1-D array of time points."""
+    times = np.asarray(t_range, dtype=float)
+    if times.ndim != 1:
+        raise ValueError(f"Time grid must be one-dimensional; received {times.ndim} dimensions")
+    if not np.all(np.isfinite(times)):
+        raise ValueError("Time grid must contain only finite values")
+    steps = np.diff(times)
+    if steps.size and np.any(steps <= 0):
+        raise ValueError(
+            "Discrete simulation requires strictly increasing time points; "
+            f"received a step of {steps.min()}. A zero step never advances and a "
+            "negative step integrates backwards."
+        )
+    return times
+
+
+def _validated_initial_total(y0_dict: dict[str, float]) -> float:
+    """Return the total initial population, rejecting non-finite or negative values.
+
+    Also rejects a non-finite total, which can occur when finite compartments sum past
+    the float range and would otherwise make the negativity tolerance infinite.
+    """
+    for compartment, value in y0_dict.items():
+        if not np.isfinite(value):
+            raise ValueError(f"Initial value for '{compartment}' must be finite; received {value}")
+        if value < 0:
+            raise ValueError(f"Initial value for '{compartment}' must be non-negative; received {value}")
+    total = float(sum(y0_dict.values()))
+    if not np.isfinite(total):
+        raise ValueError("Total initial population is not finite")
+    return total
+
+
+def _validated_population(
+    value: float, compartment: str, time: float, step_index: int, dt: float, tolerance: float
+) -> float:
+    """Check one compartment value after a step, tolerating rounding residue near zero."""
+    if not np.isfinite(value):
+        raise ValueError(
+            f"Discrete simulation diverged: '{compartment}' became {value} at "
+            f"t={time} (step {step_index}). Reduce the step size."
+        )
+    if value < -tolerance:
+        raise ValueError(
+            f"Discrete simulation produced a negative population: '{compartment}' "
+            f"became {value} at t={time} (step {step_index}). "
+            f"The step size {dt} is too large for these rates."
+        )
+    # Returned unchanged rather than clipped to zero, so total population is conserved.
+    return value
 
 
 class CompartmentalModel:
@@ -33,12 +93,16 @@ class CompartmentalModel:
             rate_expr = rate
             # Handle rate expressions
             if isinstance(rate_expr, str):
-                # Safe evaluation: build scope from parameters and state, disable builtins
                 scope = {**params, **state}
                 try:
-                    rate_val = eval(rate_expr, {"__builtins__": {}}, scope)
-                except (KeyError, NameError, ValueError, SyntaxError, TypeError, ZeroDivisionError) as e:
-                    msg = f"Invalid rate expression '{rate_expr}' in transition '{transition_label}': {e}"
+                    rate_val = evaluate_expression(rate_expr, scope)
+                except ValueError as e:
+                    shown = (
+                        rate_expr
+                        if len(rate_expr) <= _MAX_EXPRESSION_IN_ERROR
+                        else f"{rate_expr[: _MAX_EXPRESSION_IN_ERROR - 3]}..."
+                    )
+                    msg = f"Invalid rate expression '{shown}' in transition '{transition_label}': {e}"
                     raise ValueError(msg) from e
             else:
                 rate_val = rate_expr
@@ -208,15 +272,41 @@ class NetworkModel:
         return derivatives
 
     def simulate_discrete(self, y0_dict: dict[str, float], t_range: list[float]) -> dict[str, list[float]]:
-        """Run discrete-time simulation."""
+        """Run a discrete-time forward simulation.
+
+        Takes one explicit Euler step per interval in ``t_range``, using that interval's
+        own width. The grid names the points to simulate and need not be evenly spaced.
+        The method has no stability control: a step that drives a compartment to a
+        non-finite value, or significantly below zero, raises. Small negative residue from
+        floating-point error is returned unchanged so that total population is conserved.
+
+        Args:
+            y0_dict: Initial state mapping for all compartment variables.
+            t_range: Increasing sequence of time points to simulate.
+
+        Returns:
+            History of each compartment variable over time.
+
+        Raises:
+            ValueError: If the initial state or time grid is invalid, or if a step produces
+                a non-finite or significantly negative compartment value.
+        """
         state = y0_dict.copy()
         history = {c: [state[c]] for c in self.all_compartments}
 
-        for _ in t_range[1:]:
+        times = _validated_time_grid(t_range)
+        # Scale the negativity check to the initial population. Validating here also rejects
+        # a bad initial state before the early return below, not only when steps are taken.
+        tolerance = _NEGATIVITY_TOLERANCE * max(abs(_validated_initial_total(y0_dict)), 1.0)
+
+        if times.size < 2:
+            return history
+
+        for step_index, (dt, time) in enumerate(zip(np.diff(times), times[1:], strict=True), start=1):
             derivatives = self.compute_derivatives(state)
-            new_state = {c: state[c] + derivatives[c] for c in self.all_compartments}
-            state = new_state
+            state = {c: state[c] + derivatives[c] * float(dt) for c in self.all_compartments}
             for c in self.all_compartments:
+                state[c] = _validated_population(state[c], c, time, step_index, float(dt), tolerance)
                 history[c].append(state[c])
 
         return history

--- a/src/patchsim/core/model.py
+++ b/src/patchsim/core/model.py
@@ -292,6 +292,13 @@ class NetworkModel:
                 a non-finite or significantly negative compartment value.
         """
         state = y0_dict.copy()
+        expected_compartments = set(self.all_compartments)
+        missing = expected_compartments - state.keys()
+        extra = state.keys() - expected_compartments
+        if missing or extra:
+            raise ValueError(
+                f"Initial state keys do not match model compartments (missing={sorted(missing)}, extra={sorted(extra)})"
+            )
         history = {c: [state[c]] for c in self.all_compartments}
 
         times = _validated_time_grid(t_range)

--- a/tests/test_discrete_solver.py
+++ b/tests/test_discrete_solver.py
@@ -66,8 +66,22 @@ def test_initial_state_is_validated_even_when_no_steps_are_taken():
         net.simulate_discrete({"I_0": -1.0, "R_0": 0.0}, [0.0])
 
 
+def test_missing_initial_state_key_is_reported_clearly():
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match=r"missing=\['R_0'\]"):
+        net.simulate_discrete({"I_0": 100.0}, [0.0, 1.0])
+
+
+def test_extra_initial_state_key_is_reported_clearly():
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match=r"extra=\['X_0'\]"):
+        net.simulate_discrete({"I_0": 100.0, "R_0": 0.0, "X_0": 1.0}, [0.0, 1.0])
+
+
 def test_initial_total_overflowing_to_infinity_is_rejected():
-    """Each compartment is finite but their sum is not, which would make the tolerance inf."""
+    """Each compartment is finite but their sum is not."""
     import sys
 
     half_max = sys.float_info.max
@@ -79,13 +93,7 @@ def test_initial_total_overflowing_to_infinity_is_rejected():
 
 @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
 def test_non_finite_initial_state_is_rejected(bad):
-    """The divergence tolerance is derived from the initial total.
-
-    A non-finite start makes that tolerance non-finite, and every ``value < -tolerance``
-    comparison then evaluates False, disabling the negative-population guard entirely.
-    The compartment here is referenced by no transition, so the expression evaluator never
-    inspects it and cannot catch this on our behalf.
-    """
+    """A compartment unused by transitions must still be validated."""
     base = CompartmentalModel(
         compartments=["I", "R", "X"],
         parameters={"gamma": 0.2},

--- a/tests/test_discrete_solver.py
+++ b/tests/test_discrete_solver.py
@@ -1,0 +1,164 @@
+"""The discrete solver must honour the time grid it is given.
+
+It is currently unreachable from config; wiring it up as a selectable solver makes these
+guarantees load-bearing.
+"""
+
+import pytest
+
+from patchsim.core.model import CompartmentalModel, NetworkModel
+
+
+def _decay_network(gamma: float) -> NetworkModel:
+    """Single patch, pure decay I -> R, so each Euler step has a closed form."""
+    base = CompartmentalModel(
+        compartments=["I", "R"],
+        parameters={"gamma": gamma},
+        transitions=[{"transition": "I->R", "rate": "gamma * I"}],
+    )
+    return NetworkModel(base_model=base, num_patches=1, network_matrix=[[0.0]])
+
+
+def test_step_size_scales_the_update():
+    net = _decay_network(gamma=0.2)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 0.5])
+
+    # one explicit Euler step of size dt: I = I0 - gamma * I0 * dt
+    assert history["I_0"][-1] == pytest.approx(100.0 - 0.2 * 100.0 * 0.5)
+
+
+def test_halving_the_step_size_halves_the_first_move():
+    net = _decay_network(gamma=0.2)
+
+    coarse = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0])
+    fine = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 0.5])
+
+    coarse_move = 100.0 - coarse["I_0"][-1]
+    fine_move = 100.0 - fine["I_0"][-1]
+    assert fine_move == pytest.approx(coarse_move / 2.0)
+
+
+def test_each_interval_uses_its_own_step_size():
+    """A time grid names the points to simulate; it need not be evenly spaced."""
+    net = _decay_network(gamma=0.2)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0, 1.5])
+
+    # first interval dt=1.0:  100 - 0.2*100*1.0 = 80
+    # second interval dt=0.5:  80 - 0.2*80*0.5  = 72
+    assert history["I_0"][1] == pytest.approx(80.0)
+    assert history["I_0"][2] == pytest.approx(72.0)
+
+
+def test_negative_initial_population_is_rejected():
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        net.simulate_discrete({"I_0": -1.0, "R_0": 0.0}, [0.0, 1.0])
+
+
+def test_initial_state_is_validated_even_when_no_steps_are_taken():
+    """A single-point grid takes no steps but must still reject an invalid initial state."""
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        net.simulate_discrete({"I_0": -1.0, "R_0": 0.0}, [0.0])
+
+
+def test_initial_total_overflowing_to_infinity_is_rejected():
+    """Each compartment is finite but their sum is not, which would make the tolerance inf."""
+    import sys
+
+    half_max = sys.float_info.max
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match="finite"):
+        net.simulate_discrete({"I_0": half_max, "R_0": half_max}, [0.0, 1.0])
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_non_finite_initial_state_is_rejected(bad):
+    """The divergence tolerance is derived from the initial total.
+
+    A non-finite start makes that tolerance non-finite, and every ``value < -tolerance``
+    comparison then evaluates False, disabling the negative-population guard entirely.
+    The compartment here is referenced by no transition, so the expression evaluator never
+    inspects it and cannot catch this on our behalf.
+    """
+    base = CompartmentalModel(
+        compartments=["I", "R", "X"],
+        parameters={"gamma": 0.2},
+        transitions=[{"transition": "I->R", "rate": "gamma * I"}],
+    )
+    net = NetworkModel(base_model=base, num_patches=1, network_matrix=[[0.0]])
+
+    with pytest.raises(ValueError, match="finite"):
+        net.simulate_discrete({"I_0": 100.0, "R_0": 0.0, "X_0": bad}, [0.0, 1.0])
+
+
+@pytest.mark.parametrize("times", [[0.0, float("nan"), 2.0], [0.0, float("inf")]])
+def test_non_finite_time_points_are_rejected(times):
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match="finite"):
+        net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, times)
+
+
+@pytest.mark.parametrize("times", [[0.0, 0.0, 0.0], [0.0, -1.0, -2.0]])
+def test_non_positive_time_steps_are_rejected(times):
+    """A zero step never advances; a negative step integrates backwards in time."""
+    net = _decay_network(gamma=0.2)
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, times)
+
+
+def test_negative_population_is_raised_not_returned():
+    # gamma * dt > 1 makes explicit Euler overshoot below zero
+    net = _decay_network(gamma=5.0)
+
+    with pytest.raises(ValueError, match="negative"):
+        net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0, 2.0])
+
+
+def test_floating_point_noise_near_zero_is_not_flagged():
+    """A compartment emptying to zero lands just below it; that is arithmetic, not divergence."""
+    net = _decay_network(gamma=1.0 + 1e-15)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0])
+
+    assert history["I_0"][-1] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_total_population_is_conserved_exactly():
+    """Clipping residue to zero would invent mass, breaking a core model invariant.
+
+    Tolerating a tiny negative without raising is the point of the tolerance; rewriting
+    the value is a different thing, and it silently violates conservation.
+    """
+    net = _decay_network(gamma=1.0 + 1e-15)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0])
+
+    # Clipping would fabricate ~1.1e-13 here, about 8x the float64 precision at this
+    # magnitude (~1.4e-14), so the bound below distinguishes the two behaviours.
+    assert history["I_0"][-1] + history["R_0"][-1] == pytest.approx(100.0, abs=5e-14)
+
+
+def test_slightly_irregular_grid_is_integrated_not_rejected():
+    """Grids from real data are rarely exactly even; each interval is honoured as given."""
+    net = _decay_network(gamma=0.2)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0, 2.000005])
+
+    assert history["I_0"][2] == pytest.approx(80.0 - 0.2 * 80.0 * 1.000005)
+
+
+def test_unit_step_behaviour_is_unchanged():
+    net = _decay_network(gamma=0.2)
+
+    history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0, 2.0])
+
+    assert history["I_0"][1] == pytest.approx(80.0)
+    assert history["I_0"][2] == pytest.approx(64.0)

--- a/tests/test_expression_safety.py
+++ b/tests/test_expression_safety.py
@@ -1,0 +1,144 @@
+"""Rate expressions come from user-supplied YAML, so they are untrusted input.
+
+Configs are the unit PatchSim asks users to share, so evaluating one must never be able
+to run arbitrary code.
+"""
+
+import warnings  # noqa: F401  - loads catch_warnings, which the escape payload reaches
+
+import numpy as np
+import pytest
+
+from patchsim.core.expressions import evaluate
+from patchsim.core.model import CompartmentalModel
+
+
+def _model(rate: str) -> CompartmentalModel:
+    return CompartmentalModel(
+        compartments=["S", "I"],
+        parameters={"beta": 0.5},
+        transitions=[{"transition": "S->I", "rate": rate}],
+    )
+
+
+def test_rate_expression_cannot_write_to_the_filesystem(tmp_path):
+    marker = tmp_path / "escaped.txt"
+    payload = (
+        "[c for c in ().__class__.__bases__[0].__subclasses__() "
+        "if c.__name__ == 'catch_warnings'][0]()._module.__builtins__"
+        f"['open']({str(marker)!r}, 'w').write('escaped')"
+    )
+
+    try:
+        _model(payload).compute_rates({"S": 1.0, "I": 1.0})
+    except ValueError:
+        pass  # rejecting the expression is the desired outcome
+
+    assert not marker.exists(), "a rate expression executed arbitrary code"
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "().__class__",
+        "S.__class__",
+        "().__class__.__bases__[0].__subclasses__()",
+        "__import__('os')",
+        "open('x', 'w')",
+    ],
+)
+def test_disallowed_constructs_are_rejected(expr):
+    with pytest.raises(ValueError, match="not allowed"):
+        _model(expr).compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_unknown_name_is_reported_clearly():
+    with pytest.raises(ValueError, match="undefined_param"):
+        _model("undefined_param * S").compute_rates({"S": 1.0, "I": 1.0})
+
+
+@pytest.mark.parametrize(
+    ("expr", "reason"),
+    [
+        ("1e308 * 1e308", "overflow to infinity"),
+        ("0 - 1e308 * 1e308", "overflow to negative infinity"),
+        ("9**9**9**9", "exponent overflow"),
+    ],
+)
+def test_non_finite_results_are_rejected(expr, reason):
+    """A rate of inf silently poisons every downstream compartment."""
+    with pytest.raises(ValueError, match="finite"):
+        _model(expr).compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_complex_results_are_rejected():
+    """A negative base with a fractional exponent yields a complex number in Python."""
+    with pytest.raises(ValueError, match="real"):
+        _model("(0 - 1) ** 0.5").compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_division_by_zero_is_reported_as_an_expression_error():
+    with pytest.raises(ValueError, match="division"):
+        _model("beta / 0").compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_deeply_nested_expression_is_rejected_not_crashed():
+    """Nesting deep enough to exhaust the interpreter stack must surface as a config error.
+
+    Parentheses collapse during parsing, but repeated unary operators build real AST depth.
+    This stays under the length cap so it exercises the depth guard rather than that one.
+    """
+    expr = "-" * 100 + "beta"
+    with pytest.raises(ValueError, match="too deeply nested"):
+        _model(expr).compute_rates({"S": 1.0, "I": 1.0})
+
+
+@pytest.mark.parametrize("expr", ["1e400", "0 - 1e400"])
+def test_non_finite_literals_are_rejected(expr):
+    """A literal large enough to overflow reaches float() as inf without any operator."""
+    with pytest.raises(ValueError, match="finite"):
+        _model(expr).compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_non_finite_parameter_is_rejected():
+    model = CompartmentalModel(
+        compartments=["S", "I"],
+        parameters={"beta": float("inf")},
+        transitions=[{"transition": "S->I", "rate": "beta"}],
+    )
+    with pytest.raises(ValueError, match="finite"):
+        model.compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_oversized_integer_literal_is_rejected():
+    """An integer too large for float must not escape as a raw OverflowError."""
+    with pytest.raises(ValueError, match="too large"):
+        _model("9" * 400).compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_numpy_scalars_are_accepted():
+    """Solver state arrives as numpy scalars; only float64 subclasses Python float."""
+    assert evaluate("beta * S", {"beta": np.float32(0.5), "S": np.int64(4)}) == pytest.approx(2.0)
+
+
+def test_large_exponent_is_rejected_quickly():
+    """Operands are coerced to float before the operator, so a huge power overflows and is
+    rejected instead of triggering an expensive big-integer computation."""
+    with pytest.raises(ValueError, match="finite"):
+        _model("2 ** 100000").compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_oversized_expression_is_rejected_before_parsing():
+    """Bound the input before handing it to the parser, not only the AST depth after."""
+    with pytest.raises(ValueError, match="too long"):
+        _model("1+" * 10000 + "1").compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_arithmetic_expressions_still_evaluate():
+    rates = _model("beta * S * I").compute_rates({"S": 10.0, "I": 2.0})
+    assert rates["S->I"] == pytest.approx(0.5 * 10.0 * 2.0)
+
+
+def test_numeric_literals_and_precedence_are_preserved():
+    rates = _model("beta * S * I / (S + I) + 1").compute_rates({"S": 3.0, "I": 1.0})
+    assert rates["S->I"] == pytest.approx(0.5 * 3.0 * 1.0 / 4.0 + 1)

--- a/tests/test_expression_safety.py
+++ b/tests/test_expression_safety.py
@@ -9,6 +9,7 @@ import warnings  # noqa: F401  - loads catch_warnings, which the escape payload 
 import numpy as np
 import pytest
 
+from patchsim.core import expressions
 from patchsim.core.expressions import evaluate
 from patchsim.core.model import CompartmentalModel
 
@@ -132,6 +133,23 @@ def test_oversized_expression_is_rejected_before_parsing():
     """Bound the input before handing it to the parser, not only the AST depth after."""
     with pytest.raises(ValueError, match="too long"):
         _model("1+" * 10000 + "1").compute_rates({"S": 1.0, "I": 1.0})
+
+
+def test_parsed_expression_is_reused(monkeypatch):
+    expressions._parse.cache_clear()
+    parse = expressions.ast.parse
+    parse_calls = 0
+
+    def counting_parse(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return parse(*args, **kwargs)
+
+    monkeypatch.setattr(expressions.ast, "parse", counting_parse)
+
+    assert evaluate("beta * S", {"beta": 0.5, "S": 4.0}) == pytest.approx(2.0)
+    assert evaluate("beta * S", {"beta": 0.25, "S": 8.0}) == pytest.approx(2.0)
+    assert parse_calls == 1
 
 
 def test_arithmetic_expressions_still_evaluate():


### PR DESCRIPTION
## Summary

Transition rate expressions in config files were evaluated with `eval()`. Because a config
is a self-contained directory that users share and run, this meant opening a config could
execute arbitrary code. This replaces `eval()` with a small evaluator that only allows
arithmetic over named parameters and compartments.

It also fixes `simulate_discrete()`, which ignored the spacing of `t_range` and always added
derivatives with an implicit step of 1.

## Changes

- Add `patchsim.core.expressions`, an AST-based evaluator restricted to numbers, named
  values, and the basic arithmetic operators. Attribute access, function calls, indexing,
  comprehensions, and any other construct are rejected. Results that are complex,
  non-finite, or out of float range are rejected as well.
- `compute_rates` now uses this evaluator.
- `simulate_discrete` steps by each interval's width, validates the time grid and the
  initial state, and raises on divergence or negative populations instead of returning them.

## Compatibility

`NetworkModel.simulate_discrete()` now scales each step by its time step. A caller that
passed a non-unit-spaced `t_range` previously got wrong results and will now get different,
correct values. Time grids must be finite and strictly increasing; uneven spacing is
supported.

## Tests

Adds tests for expression handling (rejected constructs, non-finite / complex / oversized
results, numpy scalar inputs) and for the discrete solver (step scaling, grid validation,
initial-state validation, divergence, and population conservation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Rate expressions are now evaluated with a restricted arithmetic-only parser, preventing arbitrary code execution.
  * Rejections now cover overflow, divide-by-zero, non-finite/complex results, and unknown variables with clear errors.

* **Bug Fixes**
  * Discrete simulations now correctly use each interval’s `dt` on non-uniform, uneven time grids.
  * Time grids must be finite and strictly increasing; divergence and materially negative populations now raise errors rather than producing unreliable outputs.
  * NumPy scalar inputs (various dtypes) are accepted.

* **Tests**
  * Added safety regression coverage for expression handling and extensive discrete-solver validation (including conservation and grid behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->