### PR TITLE
feat: expose ODE and discrete solver selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- YAML configuration can select the existing `ode` or deterministic
+  explicit-Euler (`discrete`) solver. `TimeStep` defines the shared reporting
+  interval and defaults to `1.0`.
+
 ### Security
 - Transition rate expressions are now parsed and evaluated against an arithmetic-only
   allowlist instead of `eval`. Expressions come from user-supplied YAML, and configs are
@@ -15,8 +20,12 @@ All notable changes to this project will be documented in this file.
   rejected instead of returning `inf` or a complex number into the simulation.
 - Rate expressions accept numpy scalars of any dtype; previously only `float64` worked,
   because it is the one numpy type that subclasses Python's `float`.
+- Patch-specific parameter overrides now affect CLI ODE runs instead of being parsed
+  and ignored.
 
 ### Changed
+- Run CSV/PNG names, JSON summaries, and logs identify the selected solver. Existing
+  configurations still default to ODE and retain `_ode` artifact names.
 - **Breaking:** `NetworkModel.simulate_discrete()` now takes one Euler step per interval
   in `t_range`, using that interval's own width, and raises on divergence rather than
   returning negative populations. It previously assumed unit spacing regardless of the

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ PatchSim aims to support a range of modelling features commonly used in metapopu
   - Random seed control and metadata logging
   - Version-tracked configurations
 - 📦 **Modularity**:
-  - Plug-in architecture for solvers, interventions, and input data pipelines
+  - Built-in ODE and discrete solvers consume the same validated spatial network
+    format
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,7 @@ CLI
   -> load_config
   -> setup_simulation
   -> NetworkModel + initial state
-  -> Model.solve
-  -> scipy.integrate.odeint
+  -> NetworkModel.simulate_ode | NetworkModel.simulate_discrete
   -> CSV + PNG + log
 ```
 
@@ -43,11 +42,9 @@ arithmetic evaluator.
 
 ### `patchsim.core.model_runner`
 
-Provides the high-level `Model` used by the CLI. It constructs the coupled ODE
-right-hand side and solves it with `scipy.integrate.odeint`.
-
-The CLI currently uses this ODE path directly. Solver selection is not exposed in
-configuration.
+Provides the compatibility `Model` Python API. It solves the coupled ODE with
+`scipy.integrate.odeint`. The CLI dispatches through `NetworkModel` so its ODE
+and discrete paths share the same derivative function.
 
 ### `patchsim.utils`
 
@@ -67,6 +64,6 @@ implementation.
 ## Current extension boundary
 
 Built-in model names are YAML template data interpreted by the same runtime.
-PatchSim does not yet expose a plugin registry or configuration-selectable solver.
-New behavior currently requires Python changes or a new configuration using the
-existing transition language.
+PatchSim exposes configuration-selectable built-in solvers but no plugin
+registry. New solver behavior requires Python changes; new compartmental models
+can use the existing transition language.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,7 +30,7 @@ The CLI uses these conventions:
 | --- | --- |
 | `init` | Create a project from a built-in template |
 | `validate` | Load and validate a configuration and its input files |
-| `run` | Run the ODE simulation and write artifacts |
+| `run` | Run the configured solver and write artifacts |
 | `list-models` | List built-in project templates |
 | `generate-contacts` | Generate a validated spatial network CSV |
 
@@ -90,12 +90,13 @@ JSON output includes `ok`, `config`, `model_name`, `num_patches`, and `patches`.
 patchsim run -c CONFIG [--json]
 ```
 
-The command validates the same inputs, runs the current ODE solver, and writes:
+The command validates the same inputs, runs `Solver: ode` or
+`Solver: discrete`, and writes:
 
 | Path under `OutputDir` | Contents |
 | --- | --- |
-| `runs/all_patches_MODEL_ode.csv` | Reporting time and every compartment |
-| `plots/patch_timeseries_MODEL_ode.png` | One subplot per patch |
+| `runs/all_patches_MODEL_SOLVER.csv` | Reporting time and every compartment |
+| `plots/patch_timeseries_MODEL_SOLVER.png` | One subplot per patch |
 | `logs/MODEL_run_YYYYMMDD_HHMMSS.log` | Resolved inputs and run details |
 
 The JSON summary contains:
@@ -110,7 +111,9 @@ The JSON summary contains:
   "plot_path": "/path/to/output/baseline/plots/patch_timeseries_baseline_ode.png",
   "num_patches": 2,
   "patches": ["A", "B"],
-  "t_max": 60
+  "t_max": 60,
+  "solver": "ode",
+  "time_step": 1.0
 }
 ```
 
@@ -118,9 +121,10 @@ Resolved paths may be absolute. The JSON summary is not the simulation time
 series.
 
 :::{warning}
-The CSV and PNG names are deterministic. A rerun with the same `ModelName` and
-`OutputDir` overwrites them. Use one output directory per retained scenario or
-run. Logs remain separate because their names include a timestamp.
+The CSV and PNG names are deterministic per solver. A rerun with the same
+`ModelName`, solver, and `OutputDir` overwrites them, including a rerun with a
+different `TimeStep`. Use one output directory per retained scenario or run.
+Logs remain separate because their names include a timestamp.
 :::
 
 ## `list-models`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ a network. Run `patchsim validate -c CONFIG` before `patchsim run`.
 | `NetworkFile` | No | Day-zero network CSV; `null` creates a zero matrix |
 | `compartments` | No | Ordered compartment names; inferred from `SeedFile` if absent |
 | `Parameters` | No | Global names available to transition expressions |
-| `PatchParameters` | No | Parsed patch overrides; see the limitation below |
+| `PatchParameters` | No | Per-patch parameter overrides |
 
 `Compartments` with an uppercase `C` is also accepted for compatibility.
 `compartments` is the documented spelling.
@@ -197,8 +197,9 @@ See [Rate multiplication](rate-multiplication.md) for edge cases and examples.
 
 ### Infection transitions
 
-For a multi-patch ODE run, transitions from `S` to `I` or `E` are additionally
-scaled by the network infectious pressure. The built-in templates therefore use:
+For a multi-patch run with either built-in solver, transitions from `S` to `I`
+or `E` are additionally scaled by the network infectious pressure. The built-in
+templates therefore use:
 
 ```yaml
 "S -> I": "beta"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,9 @@ a network. Run `patchsim validate -c CONFIG` before `patchsim run`.
 | `SeedFile` | Yes | Initial compartment values for each seeded patch |
 | `OutputDir` | Yes | Root directory for `runs`, `plots`, and `logs` |
 | `Transitions` | Yes | Non-empty arrow-to-expression mapping |
-| `TMax` | Yes | Positive integer; outputs times `0` through `TMax - 1` |
+| `TMax` | Yes | Positive integer count of reporting points |
+| `Solver` | No | `ode` (default) or deterministic explicit Euler (`discrete`) |
+| `TimeStep` | No | Positive reporting-grid interval; defaults to `1.0` |
 | `ModelName` | For `run` | Identifier used in output filenames |
 | `NetworkFile` | No | Day-zero network CSV; `null` creates a zero matrix |
 | `compartments` | No | Ordered compartment names; inferred from `SeedFile` if absent |
@@ -41,11 +43,40 @@ SeedFile: data/seeds/seed-initial.csv
 NetworkFile: data/networks/network-static.csv
 OutputDir: output/baseline
 TMax: 60
+Solver: ode
+TimeStep: 1.0
 ```
 
 If this YAML file is `/work/study/config.yaml`, `OutputDir: output/baseline`
 resolves to `/work/study/output/baseline`, regardless of the shell's current
 directory.
+
+## Solver and time grid
+
+The reporting grid contains `TMax` points:
+
+$$
+t_k = k\,\mathrm{TimeStep}, \qquad k = 0,\ldots,\mathrm{TMax}-1.
+$$
+
+`TMax` is a point count, not the final simulated time. PatchSim does not infer
+calendar units. If rates are per day, `TimeStep` must be in days.
+
+```yaml
+Solver: discrete
+TMax: 241
+TimeStep: 0.25
+```
+
+`Solver: ode` uses LSODA with adaptive internal steps; `TimeStep` controls only
+the reported times. `Solver: discrete` takes one deterministic explicit-Euler
+step per reporting interval. It uses floating-point compartment states and is
+not a stochastic or integer-state method.
+
+Euler accuracy is not automatic. Compare a run using `dt` with one using
+`dt / 2` over the same horizon. When halving `TimeStep`, use
+`TMax_fine = 2 * (TMax_coarse - 1) + 1`. A run that remains finite and
+non-negative has not thereby demonstrated convergence.
 
 ## Patch file
 
@@ -200,13 +231,7 @@ PatchParameters:
 ```
 
 Patch names are validated, and each override is merged with the global parameter
-mapping during setup.
-
-:::{warning}
-The current CLI ODE runner still evaluates transitions with global `Parameters`.
-It parses and logs `PatchParameters` but does not apply the overrides to the ODE.
-Do not rely on patch-specific values until solver integration is completed.
-:::
+mapping during setup. Both built-in solvers use these merged parameters.
 
 ## Accepted compatibility fields
 
@@ -227,7 +252,7 @@ solver:
 - `StartDate` and `EndDate` do not change the numeric time grid; and
 - `Logging: false` does not disable the timestamped run log.
 
-`TMax` is the active simulation-length control.
+`TMax` and `TimeStep` define the reporting grid.
 
 ## Complete example
 
@@ -238,6 +263,8 @@ SeedFile: data/seeds/seed-initial.csv
 NetworkFile: data/networks/network-static.csv
 OutputDir: output/baseline
 TMax: 60
+Solver: ode
+TimeStep: 1.0
 
 compartments: [S, I, R]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,8 @@ output/
 
 The generated project contains two patches, `A` and `B`. Patch `A` starts with one
 infectious individual; patch `B` starts fully susceptible. The network file
-contains within-patch and cross-patch weights.
+contains within-patch and cross-patch weights. The generated configuration uses
+`Solver: ode` and `TimeStep: 1.0`.
 
 Choose another built-in template with `--template`:
 
@@ -76,8 +77,8 @@ and network weights.
 patchsim run -c config.yaml
 ```
 
-The generated SIR project uses `TMax: 60`, so the CSV contains reporting times
-`0.0` through `59.0`. The first row is the seed state:
+The generated SIR project uses `TMax: 60` and `TimeStep: 1.0`, so the CSV
+contains reporting times `0.0` through `59.0`. The first row is the seed state:
 
 ```csv
 time,S_0,I_0,R_0,S_1,I_1,R_1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 # PatchSim documentation
 
 PatchSim is a configuration-driven framework for compartmental epidemiology on one
-or more connected patches. The current CLI loads YAML and CSV inputs, solves the
-resulting continuous-time model with SciPy's `odeint`, and writes a time-series CSV,
-a plot, and a run log.
+or more connected patches. The CLI loads YAML and CSV inputs, runs either
+LSODA-based ODE integration or deterministic explicit Euler, and writes a
+time-series CSV, a plot, and a run log.
 
 PatchSim is under active development. Use the documentation for the installed
 version, and validate every configuration before running it.
@@ -27,8 +27,8 @@ version, and validate every configuration before running it.
   otherwise.
 - Output columns such as `I_0` use the zero-based row order from `PatchFile`; the
   suffix is not the patch identifier.
-- Examples describe behavior in the current code. Planned plugin, solver, and
-  contact-generation features are not documented as available.
+- Examples describe behavior in the current code. Planned plugin and calibration
+  features are not documented as available.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/mathematical-model.md
+++ b/docs/mathematical-model.md
@@ -131,9 +131,13 @@ chooses internal step sizes adaptively. `Solver: discrete` uses deterministic
 explicit Euler with one step per reporting interval:
 
 $$
-t_k = k\,\mathrm{TimeStep}, \qquad
-x_{k+1} = x_k + \mathrm{TimeStep}\,f(x_k).
+\Delta t_k = t_{k+1} - t_k, \qquad
+x_{k+1} = x_k + \Delta t_k\,f(x_k).
 $$
+
+CLI-generated grids are uniform, with `t_k = k * TimeStep` and
+`\Delta t_k = TimeStep`. Direct `NetworkModel.simulate_discrete` calls may
+supply an uneven increasing time grid.
 
 The discrete method can fail or be inaccurate when `TimeStep` is too large.
 Compare results at successively smaller intervals over the same horizon.

--- a/docs/mathematical-model.md
+++ b/docs/mathematical-model.md
@@ -123,15 +123,21 @@ hard-coded model classes.
 
 ## Numerical integration
 
-The CLI uses `scipy.integrate.odeint`, SciPy's interface to LSODA. LSODA chooses
-internal step sizes adaptively; `TMax` only defines reporting times:
+The two built-in solvers use the same derivative function and differ only in
+numerical integration.
+
+`Solver: ode` uses `scipy.integrate.odeint`, SciPy's interface to LSODA. LSODA
+chooses internal step sizes adaptively. `Solver: discrete` uses deterministic
+explicit Euler with one step per reporting interval:
 
 $$
-t = 0, 1, \ldots, \mathrm{TMax}-1.
+t_k = k\,\mathrm{TimeStep}, \qquad
+x_{k+1} = x_k + \mathrm{TimeStep}\,f(x_k).
 $$
 
-The current CLI does not expose solver selection or pass the scaffold's
-`Tolerance` and `MaxIter` fields to `odeint`.
+The discrete method can fail or be inaccurate when `TimeStep` is too large.
+Compare results at successively smaller intervals over the same horizon.
+`Tolerance` and `MaxIter` are not passed to `odeint`.
 
 ## Assumptions and limits
 
@@ -140,5 +146,5 @@ The current CLI does not expose solver selection or pass the scaffold's
 - Transition expressions have no explicit time variable.
 - Only compartment transfers are represented; births, deaths, or imports require
   explicit model structure.
-- Patch-specific parameter records are not yet applied by the CLI ODE runner.
+- Patch-specific parameter records are applied by both built-in solvers.
 - Network rows after `day == 0` are currently ignored.

--- a/docs/results.md
+++ b/docs/results.md
@@ -5,7 +5,7 @@ the configured `OutputDir`.
 
 ## Directory layout
 
-For `ModelName: baseline`:
+For `ModelName: baseline` and `Solver: ode`:
 
 ```text
 OutputDir/
@@ -24,10 +24,11 @@ artifacts are user-facing files.
 
 ## Retention and overwrite behavior
 
-The CSV and PNG filenames are deterministic. Running the same `ModelName` into
-the same `OutputDir` overwrites those two files. Log filenames contain a
-timestamp, so logs from separate runs are retained unless two runs start in the
-same second.
+The CSV and PNG filenames are deterministic for each solver. Running the same
+`ModelName` and solver into the same `OutputDir` overwrites those two files,
+including runs with another `TimeStep`. The discrete solver uses `_discrete`
+instead of `_ode`. Log filenames contain a timestamp, so logs from separate runs
+are retained unless two runs start in the same second.
 
 Use an output convention that identifies the scenario or retained run:
 
@@ -51,7 +52,7 @@ time,S_0,I_0,R_0,S_1,I_1,R_1
 0.0,999.0,1.0,0.0,500.0,0.0,0.0
 ```
 
-- `time` contains `0.0` through `TMax - 1`.
+- `time` contains `k * TimeStep` for `k = 0` through `TMax - 1`.
 - `COMPARTMENT_INDEX` identifies a compartment and zero-based patch index.
 - Patch indices follow `PatchFile` row order.
 
@@ -66,8 +67,8 @@ B,500
 `I_0` is infectious population in patch `A`, and `I_1` is infectious population
 in patch `B`.
 
-Compartment values are floating point because the current solver integrates
-continuous ODE states.
+Compartment values are floating point for both built-in solvers. The discrete
+solver is deterministic explicit Euler, not an integer-state method.
 
 ## Plot
 
@@ -85,8 +86,9 @@ The timestamped log records:
 - resolved patch, seed, network, and output paths;
 - Python and platform information;
 - patch order;
-- configured transitions; and
-- final CSV and PNG paths.
+- configured transitions;
+- final CSV and PNG paths; and
+- selected solver and `TimeStep`.
 
 The log does not currently contain internal LSODA diagnostics, package-version
 provenance, or a copy of the configuration. Archive the config and input CSVs
@@ -97,8 +99,9 @@ alongside retained outputs.
 ## JSON run summary
 
 `patchsim run -c config.yaml --json` emits a summary with the resolved output
-directory, CSV path, plot path, patch list, and `TMax`. It does not embed the
-time series. Logs continue to use standard error and the log file.
+directory, CSV path, plot path, patch list, `TMax`, solver, and `TimeStep`. It
+does not embed the time series. Logs continue to use standard error and the log
+file.
 
 ## Basic analysis
 

--- a/docs/simulation-workflow.md
+++ b/docs/simulation-workflow.md
@@ -31,20 +31,24 @@ loaded.
 `patchsim run` creates reporting times with:
 
 ```python
-np.arange(TMax, dtype=float)
+np.arange(TMax, dtype=float) * TimeStep
 ```
 
-The high-level model constructs the coupled ODE and solves it with
-`scipy.integrate.odeint`. Internal LSODA steps are adaptive; output is sampled at
-the reporting times.
+Both built-in solvers use the same coupled derivative function. `Solver: ode`
+uses `scipy.integrate.odeint`; internal LSODA steps are adaptive and output is
+sampled at the reporting times. `Solver: discrete` takes one explicit-Euler step
+per reporting interval.
 
 ## 5. Write artifacts
 
-PatchSim writes:
+For `Solver: ode`, PatchSim writes:
 
 - `runs/all_patches_MODEL_ode.csv`;
 - `plots/patch_timeseries_MODEL_ode.png`; and
 - `logs/MODEL_run_TIMESTAMP.log`.
+
+The discrete solver replaces `_ode` with `_discrete` in the CSV and PNG names.
+The log and JSON run summary record the selected solver and `TimeStep`.
 
 The CSV and PNG are replaced by a rerun with the same `ModelName` and
 `OutputDir`. See [Results](results.md) for retention conventions.

--- a/docs/simulation-workflow.md
+++ b/docs/simulation-workflow.md
@@ -50,8 +50,8 @@ For `Solver: ode`, PatchSim writes:
 The discrete solver replaces `_ode` with `_discrete` in the CSV and PNG names.
 The log and JSON run summary record the selected solver and `TimeStep`.
 
-The CSV and PNG are replaced by a rerun with the same `ModelName` and
-`OutputDir`. See [Results](results.md) for retention conventions.
+The CSV and PNG are replaced by a rerun with the same `ModelName`, `OutputDir`,
+and solver. See [Results](results.md) for retention conventions.
 
 ## Reproducible run checklist
 

--- a/src/patchsim/cli.py
+++ b/src/patchsim/cli.py
@@ -71,6 +71,8 @@ def _cmd_validate(config_path: str, *, json_output: bool = False, schema: bool =
             "model_name": config.get("ModelName"),
             "num_patches": num_patches,
             "patches": patches,
+            "solver": config["Solver"],
+            "time_step": config["TimeStep"],
         }
     return None
 

--- a/src/patchsim/core/model.py
+++ b/src/patchsim/core/model.py
@@ -10,8 +10,7 @@ from scipy.integrate import odeint
 
 from patchsim.core.expressions import evaluate as evaluate_expression
 
-# Negative values within this fraction of the initial population are treated as rounding error.
-_NEGATIVITY_TOLERANCE = 1e-9
+_NEGATIVITY_ROUNDOFF_FACTOR = 64
 _MAX_EXPRESSION_IN_ERROR = 80  # max expression length shown in error messages
 
 
@@ -36,7 +35,7 @@ def _validated_initial_total(y0_dict: dict[str, float]) -> float:
     """Return the total initial population, rejecting non-finite or negative values.
 
     Also rejects a non-finite total, which can occur when finite compartments sum past
-    the float range and would otherwise make the negativity tolerance infinite.
+    the float range and would make population-based rates invalid.
     """
     for compartment, value in y0_dict.items():
         if not np.isfinite(value):
@@ -56,13 +55,13 @@ def _validated_population(
     if not np.isfinite(value):
         raise ValueError(
             f"Discrete simulation diverged: '{compartment}' became {value} at "
-            f"t={time} (step {step_index}). Reduce the step size."
+            f"t={time} (step {step_index}). Reduce TimeStep or the supplied interval width."
         )
     if value < -tolerance:
         raise ValueError(
             f"Discrete simulation produced a negative population: '{compartment}' "
             f"became {value} at t={time} (step {step_index}). "
-            f"The step size {dt} is too large for these rates."
+            f"TimeStep or the supplied interval width ({dt}) is too large for these rates."
         )
     # Returned unchanged rather than clipped to zero, so total population is conserved.
     return value
@@ -302,19 +301,22 @@ class NetworkModel:
         history = {c: [state[c]] for c in self.all_compartments}
 
         times = _validated_time_grid(t_range)
-        # Scale the negativity check to the initial population. Validating here also rejects
-        # a bad initial state before the early return below, not only when steps are taken.
-        tolerance = _NEGATIVITY_TOLERANCE * max(abs(_validated_initial_total(y0_dict)), 1.0)
+        # Validate before the early return, not only when steps are taken.
+        _validated_initial_total(y0_dict)
 
         if times.size < 2:
             return history
 
         for step_index, (dt, time) in enumerate(zip(np.diff(times), times[1:], strict=True), start=1):
             derivatives = self.compute_derivatives(state)
-            state = {c: state[c] + derivatives[c] * float(dt) for c in self.all_compartments}
+            next_state = {}
             for c in self.all_compartments:
-                state[c] = _validated_population(state[c], c, time, step_index, float(dt), tolerance)
-                history[c].append(state[c])
+                delta = derivatives[c] * float(dt)
+                value = state[c] + delta
+                tolerance = _NEGATIVITY_ROUNDOFF_FACTOR * np.finfo(float).eps * max(abs(state[c]), abs(delta), 1.0)
+                next_state[c] = _validated_population(value, c, time, step_index, float(dt), tolerance)
+                history[c].append(next_state[c])
+            state = next_state
 
         return history
 

--- a/src/patchsim/core/simulation.py
+++ b/src/patchsim/core/simulation.py
@@ -5,6 +5,7 @@ ODE and discrete simulation logic is implemented in core/model.py.
 
 import os
 import re
+from numbers import Real
 from pathlib import Path
 from typing import Any
 
@@ -13,10 +14,13 @@ import pandas as pd
 import yaml
 
 from patchsim.core.model import CompartmentalModel, NetworkModel
-from patchsim.core.model_runner import Model
 from patchsim.utils.logger import setup_logger
+from patchsim.utils.viz import plot_patch_subplots
 
 EPSILON = 1e-6
+DEFAULT_SOLVER = "ode"
+DEFAULT_TIME_STEP = 1.0
+SOLVERS = ("ode", "discrete")
 
 
 MODEL_TEMPLATE_CONFIGS: dict[str, dict[str, Any]] = {
@@ -58,6 +62,12 @@ def get_config_schema() -> dict[str, Any]:
             "OutputDir": {"type": "string"},
             "ModelName": {"type": "string"},
             "TMax": {"type": "integer", "minimum": 1},
+            "Solver": {"type": "string", "enum": list(SOLVERS), "default": DEFAULT_SOLVER},
+            "TimeStep": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "default": DEFAULT_TIME_STEP,
+            },
             "Tolerance": {"type": ["number", "string"]},
             "MaxIter": {"type": "integer", "minimum": 1},
             "StartDate": {"type": ["string", "null"]},
@@ -125,6 +135,8 @@ def get_init_template_config(template_name: str, project_name: str) -> dict[str,
         "Logging": False,
         "ModelName": project_name,
         "TMax": 60,
+        "Solver": DEFAULT_SOLVER,
+        "TimeStep": DEFAULT_TIME_STEP,
         "Tolerance": 1e-8,
         "MaxIter": 10000,
         "StartDate": "2020-01-01",
@@ -159,6 +171,10 @@ def load_config(config_path: str) -> dict[str, Any]:
                 f"Please add '{field}' to your config file."
             )
 
+    solver, _t_max, time_step = get_run_settings(config)
+    config["Solver"] = solver
+    config["TimeStep"] = time_step
+
     # Resolve relative paths against the config file directory.
     cfg_dir = cfg_path.parent
     for key in ["PatchFile", "SeedFile", "NetworkFile", "OutputDir"]:
@@ -169,6 +185,25 @@ def load_config(config_path: str) -> dict[str, Any]:
                 config[key] = str((cfg_dir / p).resolve())
 
     return config
+
+
+def get_run_settings(config: dict[str, Any]) -> tuple[str, int, float]:
+    """Validate and return the solver, reporting-point count, and grid interval."""
+    solver = config.get("Solver", DEFAULT_SOLVER)
+    if not isinstance(solver, str) or solver not in SOLVERS:
+        raise ValueError(f"'Solver' must be one of {list(SOLVERS)}; received {solver!r}")
+
+    t_max = config.get("TMax")
+    if isinstance(t_max, bool) or not isinstance(t_max, int) or t_max <= 0:
+        raise ValueError(f"'TMax' must be a positive integer count of reporting points; received {t_max!r}")
+
+    time_step = config.get("TimeStep", DEFAULT_TIME_STEP)
+    if isinstance(time_step, bool) or not isinstance(time_step, Real):
+        raise ValueError(f"'TimeStep' must be a finite positive number; received {time_step!r}")
+    time_step = float(time_step)
+    if not np.isfinite(time_step) or time_step <= 0:
+        raise ValueError(f"'TimeStep' must be a finite positive number; received {time_step!r}")
+    return solver, t_max, time_step
 
 
 def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, float], list, int]:
@@ -372,6 +407,10 @@ def run_simulation(
     Returns:
         A summary dictionary describing the generated artifacts.
     """
+    solver, t_max, time_step = get_run_settings(config)
+    config["Solver"] = solver
+    config["TimeStep"] = time_step
+
     # Create output directories
     for subdir in ["plots", "runs"]:
         dir_path = os.path.join(config["OutputDir"], subdir)
@@ -383,33 +422,35 @@ def run_simulation(
     # Set up logger
     logger = setup_logger(model_name, config, num_patches, patches, net.base_model)
 
-    # Validate and construct time range
-    t_max = config.get("TMax")
-    if not isinstance(t_max, int) or t_max <= 0:
-        raise ValueError(
-            f"Invalid 'TMax' value: {t_max}\n"
-            "'TMax' must be a positive integer (number of time steps).\n"
-            "Example: TMax: 100"
-        )
-    t_range = np.arange(t_max, dtype=float)
+    t_range = np.arange(t_max, dtype=float) * time_step
 
     # Run simulation
-    model = Model(net, compartments=list(net.base_model.compartments))
-    out_ode = model.solve(y0, t_range)
+    if solver == "ode":
+        _times, results = net.simulate_ode(y0, t_range)
+    else:
+        results = net.simulate_discrete(y0, t_range)
 
     # Save results
-    out_df = pd.DataFrame(out_ode)
+    out_df = pd.DataFrame(results)
     out_df["time"] = t_range
     cols = ["time"] + [c for c in out_df.columns if c != "time"]
     out_df = out_df[cols]
 
-    csv_path = os.path.join(runs_dir, f"all_patches_{model_name}_ode.csv")
+    csv_path = os.path.join(runs_dir, f"all_patches_{model_name}_{solver}.csv")
     out_df.to_csv(csv_path, index=False)
     logger.info(f"Saved simulation output to {csv_path}")
 
-    model.visualize(t_range, out_ode, patches, plots_dir, model_name)
+    plot_patch_subplots(
+        t_range,
+        results,
+        patches,
+        plots_dir,
+        model_name,
+        compartments=list(net.base_model.compartments),
+        solver=solver,
+    )
 
-    plot_path = os.path.join(plots_dir, f"patch_timeseries_{model_name}_ode.png")
+    plot_path = os.path.join(plots_dir, f"patch_timeseries_{model_name}_{solver}.png")
     logger.info(f"Saved all patch subplots to {plot_path}")
 
     return {
@@ -420,4 +461,6 @@ def run_simulation(
         "num_patches": num_patches,
         "patches": patches,
         "t_max": t_max,
+        "solver": solver,
+        "time_step": time_step,
     }

--- a/src/patchsim/templates/project/config.yaml
+++ b/src/patchsim/templates/project/config.yaml
@@ -14,6 +14,8 @@ ModelName: {{PROJECT_NAME}}
 
 # Simulation parameters
 TMax: 60
+Solver: ode
+TimeStep: 1.0
 Tolerance: 1e-8
 MaxIter: 10000
 StartDate: 2020-01-01

--- a/src/patchsim/utils/logger.py
+++ b/src/patchsim/utils/logger.py
@@ -55,6 +55,8 @@ def setup_logger(model_name, config, num_patches, patches, base_model):
     logger.info(f"SeedFile: {config['SeedFile']}")
     logger.info(f"NetworkFile: {config['NetworkFile']}")
     logger.info(f"OutputDir: {config['OutputDir']}")
+    logger.info(f"Solver: {config['Solver']}")
+    logger.info(f"TimeStep: {config['TimeStep']}")
     logger.info(f"TMax: {config['TMax']}")
     logger.info(f"Num patches: {num_patches}")
     logger.info(f"Patch list: {patches}")

--- a/src/patchsim/utils/viz.py
+++ b/src/patchsim/utils/viz.py
@@ -4,7 +4,16 @@ import os
 import matplotlib.pyplot as plt
 
 
-def plot_patch_subplots(t_range, out_ode, patches, output_dir, model_name, patch_parameters=None, compartments=None):
+def plot_patch_subplots(
+    t_range,
+    out_ode,
+    patches,
+    output_dir,
+    model_name,
+    patch_parameters=None,
+    compartments=None,
+    solver="ode",
+):
     """
     Plots all patches as subplots in a single figure and saves the figure.
     """
@@ -21,7 +30,8 @@ def plot_patch_subplots(t_range, out_ode, patches, output_dir, model_name, patch
         comps = compartments or [k[: -len(f"_{i}")] for k in out_ode if k.endswith(f"_{i}")]
         for c in comps:
             ax.plot(t_range, out_ode[f"{c}_{i}"], label=c)
-        title = f"Patch {patch} (ODE)"
+        solver_label = "ODE" if solver == "ode" else "Discrete"
+        title = f"Patch {patch} ({solver_label})"
         if patch_parameters and patch in patch_parameters:
             params = patch_parameters[patch]
             param_str = ", ".join(f"{k}={v}" for k, v in params.items())
@@ -35,5 +45,5 @@ def plot_patch_subplots(t_range, out_ode, patches, output_dir, model_name, patch
         fig.delaxes(axes[j])
     plt.tight_layout()
     os.makedirs(output_dir, exist_ok=True)
-    plt.savefig(os.path.join(output_dir, f"patch_timeseries_{model_name}_ode.png"))
+    plt.savefig(os.path.join(output_dir, f"patch_timeseries_{model_name}_{solver}.png"))
     plt.close()

--- a/tests/test_discrete_solver.py
+++ b/tests/test_discrete_solver.py
@@ -1,8 +1,4 @@
-"""The discrete solver must honour the time grid it is given.
-
-It is currently unreachable from config; wiring it up as a selectable solver makes these
-guarantees load-bearing.
-"""
+"""Tests for explicit-Euler stepping and numerical safeguards."""
 
 import pytest
 
@@ -126,7 +122,7 @@ def test_negative_population_is_raised_not_returned():
     # gamma * dt > 1 makes explicit Euler overshoot below zero
     net = _decay_network(gamma=5.0)
 
-    with pytest.raises(ValueError, match="negative"):
+    with pytest.raises(ValueError, match="TimeStep"):
         net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0, 2.0])
 
 
@@ -137,6 +133,40 @@ def test_floating_point_noise_near_zero_is_not_flagged():
     history = net.simulate_discrete({"I_0": 100.0, "R_0": 0.0}, [0.0, 1.0])
 
     assert history["I_0"][-1] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_roundoff_allowance_scales_with_large_compartment():
+    net = _decay_network(gamma=1.0 + 1e-15)
+
+    history = net.simulate_discrete({"I_0": 1e12, "R_0": 0.0}, [0.0, 1.0])
+
+    assert history["I_0"][-1] == pytest.approx(0.0, abs=0.01)
+
+
+def test_large_compartment_still_rejects_material_overshoot():
+    net = _decay_network(gamma=1.0 + 1e-12)
+
+    with pytest.raises(ValueError, match="negative"):
+        net.simulate_discrete({"I_0": 1e12, "R_0": 0.0}, [0.0, 1.0])
+
+
+def test_roundoff_allowance_tracks_compartment_growth():
+    base = CompartmentalModel(
+        compartments=["I", "B", "C"],
+        parameters={"gamma": 1.0 + 1e-15},
+        transitions=[
+            {"transition": "I->B", "rate": "I"},
+            {"transition": "B->C", "rate": "gamma * B"},
+        ],
+    )
+    net = NetworkModel(base_model=base, num_patches=1, network_matrix=[[0.0]])
+
+    history = net.simulate_discrete(
+        {"I_0": 1e12, "B_0": 0.0, "C_0": 0.0},
+        [0.0, 1.0, 2.0],
+    )
+
+    assert history["B_0"][-1] == pytest.approx(0.0, abs=0.01)
 
 
 def test_total_population_is_conserved_exactly():
@@ -152,6 +182,21 @@ def test_total_population_is_conserved_exactly():
     # Clipping would fabricate ~1.1e-13 here, about 8x the float64 precision at this
     # magnitude (~1.4e-14), so the bound below distinguishes the two behaviours.
     assert history["I_0"][-1] + history["R_0"][-1] == pytest.approx(100.0, abs=5e-14)
+
+
+def test_large_other_compartment_does_not_hide_material_negative_value():
+    base = CompartmentalModel(
+        compartments=["I", "R", "X"],
+        parameters={"gamma": 1.0 + 1e-8},
+        transitions=[{"transition": "I->R", "rate": "gamma * I"}],
+    )
+    net = NetworkModel(base_model=base, num_patches=1, network_matrix=[[0.0]])
+
+    with pytest.raises(ValueError, match="negative"):
+        net.simulate_discrete(
+            {"I_0": 1.0, "R_0": 0.0, "X_0": 1e18},
+            [0.0, 1.0],
+        )
 
 
 def test_slightly_irregular_grid_is_integrated_not_rejected():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,8 @@
 import json
 import subprocess
 
+import yaml
+
 
 def test_patchsim_import():
     import patchsim
@@ -89,6 +91,9 @@ def test_cli_init_template_scaffold(tmp_path):
     config_text = (project_dir / "config.yaml").read_text(encoding="utf-8")
     assert "E" in config_text
     assert "S -> E" in config_text
+    config = yaml.safe_load(config_text)
+    assert config["Solver"] == "ode"
+    assert config["TimeStep"] == 1.0
 
 
 def test_cli_init_scaffold(tmp_path):

--- a/tests/test_solver_selection.py
+++ b/tests/test_solver_selection.py
@@ -1,0 +1,221 @@
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from patchsim.core.model import CompartmentalModel, NetworkModel
+from patchsim.core.model_runner import Model
+from patchsim.core.simulation import (
+    MODEL_TEMPLATE_CONFIGS,
+    get_config_schema,
+    get_run_settings,
+    load_config,
+    run_simulation,
+    setup_simulation,
+)
+from patchsim.utils.geo import generate_contacts
+
+
+def _write_project(tmp_path: Path) -> Path:
+    patch_file = tmp_path / "patches.csv"
+    seed_file = tmp_path / "seeds.csv"
+    network_file = tmp_path / "network.csv"
+    pd.DataFrame({"patch": ["A", "B"], "population": [100, 200]}).to_csv(patch_file, index=False)
+    pd.DataFrame({"patch": ["A", "B"], "S": [99, 200], "I": [1, 0], "R": [0, 0]}).to_csv(seed_file, index=False)
+    pd.DataFrame(
+        {
+            "day": [0, 0, 0, 0],
+            "source": ["A", "A", "B", "B"],
+            "target": ["A", "B", "A", "B"],
+            "weight": [0.8, 0.2, 0.2, 0.8],
+        }
+    ).to_csv(network_file, index=False)
+    config = {
+        "ModelName": "solver-test",
+        "PatchFile": str(patch_file),
+        "SeedFile": str(seed_file),
+        "NetworkFile": str(network_file),
+        "OutputDir": str(tmp_path / "output"),
+        "TMax": 5,
+        "compartments": ["S", "I", "R"],
+        "Parameters": {"beta": 0.08, "gamma": 0.1},
+        "Transitions": {"S -> I": "beta", "I -> R": "gamma * I"},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["patchsim", *args], capture_output=True, text=True)
+
+
+def test_schema_declares_solver_and_time_step_defaults():
+    properties = get_config_schema()["properties"]
+    assert properties["Solver"] == {"type": "string", "enum": ["ode", "discrete"], "default": "ode"}
+    assert properties["TimeStep"] == {
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "default": 1.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("Solver", "rk45", "Solver"),
+        ("TMax", True, "TMax"),
+        ("TMax", 1.5, "TMax"),
+        ("TMax", 0, "TMax"),
+        ("TimeStep", True, "TimeStep"),
+        ("TimeStep", 0, "TimeStep"),
+        ("TimeStep", float("nan"), "TimeStep"),
+        ("TimeStep", float("inf"), "TimeStep"),
+    ],
+)
+def test_run_settings_reject_invalid_values(field, value, message):
+    config = {"TMax": 5, field: value}
+    with pytest.raises(ValueError, match=message):
+        get_run_settings(config)
+
+
+@pytest.mark.parametrize("command", ["validate", "run"])
+def test_cli_rejects_run_settings_before_creating_outputs(tmp_path, command):
+    config_path = _write_project(tmp_path)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["TimeStep"] = 0
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    result = _run_cli(command, "-c", str(config_path))
+
+    assert result.returncode != 0
+    assert "TimeStep" in result.stderr
+    assert not Path(config["OutputDir"]).exists()
+
+
+def test_absent_and_explicit_ode_config_are_equivalent(tmp_path):
+    config_path = _write_project(tmp_path)
+
+    default_run = _run_cli("run", "-c", str(config_path), "--json")
+    assert default_run.returncode == 0, default_run.stderr
+    default_summary = json.loads(default_run.stdout)
+    default_frame = pd.read_csv(default_summary["csv_path"])
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["Solver"] = "ode"
+    config["TimeStep"] = 1.0
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    explicit_run = _run_cli("run", "-c", str(config_path), "--json")
+    assert explicit_run.returncode == 0, explicit_run.stderr
+    explicit_summary = json.loads(explicit_run.stdout)
+    explicit_frame = pd.read_csv(explicit_summary["csv_path"])
+
+    assert default_summary["solver"] == explicit_summary["solver"] == "ode"
+    assert default_summary["time_step"] == explicit_summary["time_step"] == 1.0
+    assert default_summary["csv_path"] == explicit_summary["csv_path"]
+    assert default_summary["plot_path"] == explicit_summary["plot_path"]
+    pd.testing.assert_frame_equal(default_frame, explicit_frame)
+
+
+def test_discrete_cli_reports_method_and_time_grid(tmp_path):
+    config_path = _write_project(tmp_path)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config.update({"Solver": "discrete", "TimeStep": 0.5, "TMax": 5})
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    validation = _run_cli("validate", "-c", str(config_path), "--json")
+    run = _run_cli("run", "-c", str(config_path), "--json")
+
+    assert validation.returncode == 0, validation.stderr
+    assert json.loads(validation.stdout)["solver"] == "discrete"
+    assert json.loads(validation.stdout)["time_step"] == 0.5
+    assert run.returncode == 0, run.stderr
+    summary = json.loads(run.stdout)
+    assert summary["solver"] == "discrete"
+    assert summary["time_step"] == 0.5
+    assert summary["csv_path"].endswith("_discrete.csv")
+    assert summary["plot_path"].endswith("_discrete.png")
+    frame = pd.read_csv(summary["csv_path"])
+    assert frame["time"].tolist() == [0.0, 0.5, 1.0, 1.5, 2.0]
+    assert frame.iloc[0][["S_0", "I_0", "R_0"]].tolist() == [99.0, 1.0, 0.0]
+    log_text = next((Path(config["OutputDir"]) / "logs").glob("*.log")).read_text(encoding="utf-8")
+    assert "Solver: discrete" in log_text
+    assert "TimeStep: 0.5" in log_text
+
+
+@pytest.mark.parametrize("template_name", sorted(MODEL_TEMPLATE_CONFIGS))
+def test_shared_ode_derivatives_match_current_runner(template_name):
+    template = MODEL_TEMPLATE_CONFIGS[template_name]
+    transitions = [{"transition": key.replace(" ", ""), "rate": rate} for key, rate in template["Transitions"].items()]
+    base = CompartmentalModel(template["compartments"], template["Parameters"], transitions)
+    network = NetworkModel(base, 2, [[0.8, 0.2], [0.2, 0.8]])
+    y0 = {f"{compartment}_{patch}": 0.0 for patch in range(2) for compartment in template["compartments"]}
+    y0["S_0"] = 99.0
+    y0["I_0"] = 1.0
+    y0["S_1"] = 100.0
+    times = np.arange(20, dtype=float)
+
+    current = Model(network, template["compartments"]).solve(y0, times)
+    _times, shared = network.simulate_ode(y0, times)
+
+    for compartment in current:
+        np.testing.assert_allclose(current[compartment], shared[compartment], rtol=1e-12, atol=1e-12)
+
+
+def test_patch_parameters_affect_both_solver_paths():
+    base = CompartmentalModel(
+        ["I", "R"],
+        {"gamma": 0.1},
+        [{"transition": "I->R", "rate": "gamma * I"}],
+    )
+    network = NetworkModel(base, 2, [[0.0, 0.0], [0.0, 0.0]])
+    network.patch_names = ["A", "B"]
+    network.patch_parameters = {"A": {"gamma": 0.1}, "B": {"gamma": 0.2}}
+    y0 = {"I_0": 100.0, "R_0": 0.0, "I_1": 100.0, "R_1": 0.0}
+    times = [0.0, 0.5]
+
+    discrete = network.simulate_discrete(y0, times)
+    _times, ode = network.simulate_ode(y0, times)
+
+    assert discrete["I_0"][-1] == pytest.approx(95.0)
+    assert discrete["I_1"][-1] == pytest.approx(90.0)
+    assert ode["I_1"][-1] < ode["I_0"][-1]
+
+
+@pytest.mark.parametrize("solver", ["ode", "discrete"])
+def test_both_solvers_consume_generated_contact_network(tmp_path, solver):
+    regions = tmp_path / "regions.csv"
+    network_file = tmp_path / "contacts.csv"
+    regions.write_text("patch,lat,lon\nA,0,0\nB,0,1\n", encoding="utf-8")
+    generate_contacts(
+        regions,
+        network_file,
+        id_column="patch",
+        kernel="distance",
+        decay=2.0,
+        min_distance_km=0.001,
+        normalize="row",
+        self_share=0.8,
+    )
+    config_path = _write_project(tmp_path)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config.update(
+        {
+            "NetworkFile": str(network_file),
+            "OutputDir": str(tmp_path / f"output-{solver}"),
+            "Solver": solver,
+            "TimeStep": 0.5,
+        }
+    )
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    loaded = load_config(str(config_path))
+    net, y0, patches, num_patches = setup_simulation(loaded)
+    summary = run_simulation(loaded, loaded["ModelName"], net, y0, patches, num_patches)
+
+    assert Path(summary["csv_path"]).is_file()
+    assert summary["solver"] == solver


### PR DESCRIPTION
## Summary

- expose `Solver: ode|discrete` and positive `TimeStep` configuration with backward-compatible defaults
- route both built-in solvers through the shared `NetworkModel` derivative path, including patch-specific parameters
- identify solver and reporting interval in artifacts, JSON, logs, and user documentation

## Numerical behavior

- define `TMax` as the reporting-point count on `time[k] = k * TimeStep`
- document explicit Euler's continuous-valued semantics and same-horizon step-halving check
- reject non-finite or materially negative discrete states using a per-operation roundoff allowance

## Verification

- `uv run --frozen --extra lint ruff check .`
- `uv run --frozen --extra lint ruff format --check .`
- `uv run --frozen --extra test pytest -q` (`124 passed`)
- `uv run --frozen --extra docs sphinx-build -b html docs /tmp/patchsim-docs-solver-final -W`
- `uv build`
- empirical ODE and discrete CLI runs, including `dt=1` versus `dt=0.5` on the same horizon
- Playwright checks of the rendered configuration guide at desktop and narrow viewports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ODE and deterministic discrete solvers.
  * Added `TimeStep` configuration for controlling reporting intervals.
  * Validation and run summaries now show the selected solver and time step.
  * Output filenames and plots identify the solver used.
  * Patch-specific parameter overrides now apply to both solver options.

* **Bug Fixes**
  * Improved discrete-solver safeguards for numerical rounding and invalid populations.

* **Documentation**
  * Updated configuration, CLI, workflow, results, and getting-started guidance for solver selection and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->