### PR TITLE
docs: link repository from site header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,16 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/dsih-artpark/patchsim",
+            "icon": "fa-brands fa-square-github",
+            "type": "fontawesome",
+        }
+    ]
+}
 
 # MyST configuration
 myst_enable_extensions = [


### PR DESCRIPTION
## Summary

- add the PatchSim GitHub repository to the documentation header
- use the theme's explicit icon-link configuration

## Verification

- strict Sphinx build with warnings as errors
- Ruff check and format check for `docs/conf.py`
- Playwright verification at desktop and mobile widths, including the mobile navigation drawer
