### PR TITLE
feat: add generic group stratification

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ Compared to many epidemiology tools that are either code-heavy or tightly bound 
 PatchSim aims to support a range of modelling features commonly used in metapopulation disease simulations:
 
 - 🗺️ **Spatial Networks**: Represent geographical units (e.g., subdistricts, regions) as interconnected patches with movement/contact matrices.
-- 👥 **Stratification by Population Attributes**:
-  - **Age groups**
-  - **Species (e.g., cattle, buffalo)**
-  - **Risk groups or occupations**
+- 👥 **Stratification by Population Attributes**: Use a generic group axis for age,
+  species, behavioural risk, occupation, or another categorical partition, with an
+  explicitly supplied interaction matrix.
 - 🧪 **Disease Agnostic Compartment Models**:
   - SIR, SEIR, SIRS and extensions
   - Supports both discrete timestep and ODE-based solvers

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -71,6 +71,7 @@ Validation checks:
 - patch and population columns;
 - positive patch populations;
 - seed compartments, values, patch identifiers, and population totals;
+- optional group populations, seed coverage, interaction labels, weights, and units;
 - transition arrow syntax, compartment names, and expression identifiers;
 - patch-parameter identifiers; and
 - day-zero network patch identifiers and non-negative weights.
@@ -82,6 +83,8 @@ Configuration is valid: config.yaml
 ```
 
 JSON output includes `ok`, `config`, `model_name`, `num_patches`, and `patches`.
+Grouped validation additionally includes `num_groups`, ordered `groups`, and
+interaction diagnostics suitable for saving with a study.
 `--schema` prints the JSON Schema used for editor and tooling integration.
 
 ## `run`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,12 +27,18 @@ a network. Run `patchsim validate -c CONFIG` before `patchsim run`.
 | `TimeStep` | No | Positive reporting-grid interval; defaults to `1.0` |
 | `ModelName` | For `run` | Identifier used in output filenames |
 | `NetworkFile` | No | Day-zero network CSV; `null` creates a zero matrix |
+| `GroupFile` | Grouped runs | Patch-by-group populations |
+| `InteractionFile` | Grouped runs | Shared focal-by-contributor group matrix |
+| `InteractionUnits` | Grouped runs | Non-empty description of interaction-weight units |
 | `compartments` | No | Ordered compartment names; inferred from `SeedFile` if absent |
 | `Parameters` | No | Global names available to transition expressions |
 | `PatchParameters` | No | Per-patch parameter overrides |
 
 `Compartments` with an uppercase `C` is also accepted for compatibility.
 `compartments` is the documented spelling.
+
+The three grouped-run fields are optional as a set and invalid when only partly
+configured. See [Group stratification](group-stratification.md).
 
 ## File paths and output
 
@@ -112,6 +118,10 @@ For every seed row:
 If `compartments` is provided, the seed compartment columns must match it
 exactly. If it is omitted, PatchSim infers compartments from all seed columns
 other than `patch`.
+
+Grouped runs instead use one row per patch/group pair and exclude both `patch`
+and `group` when inferring compartments. Group populations and the full file
+contract are documented in [Group stratification](group-stratification.md).
 
 ## Network file
 

--- a/docs/group-stratification.md
+++ b/docs/group-stratification.md
@@ -1,0 +1,226 @@
+# Group stratification
+
+PatchSim can divide each geographic patch into one categorical grouping. The group
+labels and meaning are supplied by the modeller. Examples include:
+
+- age bands;
+- behavioural risk categories in sexually transmitted infection models;
+- occupations such as construction workers;
+- species; and
+- intervention or exposure categories.
+
+Grouped runs require `GroupFile`, `InteractionFile`, and `InteractionUnits`
+together. The worked example below contains the complete files and config.
+
+The interaction matrix may come from measurements, published estimates, or a documented
+proxy. PatchSim validates its numeric and identifier contracts, but cannot establish
+that the grouping or proxy is appropriate for the modelled transmission process.
+
+## Group populations
+
+`GroupFile` uses the columns `patch`, `group`, and `population` to allocate each
+`PatchFile` population across the same group set.
+
+Every patch/group pair must appear once. Values must be finite and non-negative, and
+group populations must sum to the corresponding patch population. A zero-population
+stratum is valid.
+
+Group order follows the rows for the first patch in `PatchFile`. Rows for other patches
+may use any order. Labels must match exactly across group, seed, and interaction files.
+
+## Initial state
+
+For grouped runs, add `group` after `patch` in `SeedFile`, followed by the
+configured compartment columns.
+
+Every patch/group pair must appear once. Its compartments must be finite,
+non-negative, and sum to that stratum's population.
+
+## Interaction matrix
+
+`InteractionFile` is a static matrix shared by all patches. It uses
+`focal_group`, `contributor_group`, and `weight`.
+
+`focal_group` is the susceptible or exposed row. `contributor_group` is the infectious
+column. This distinction matters for asymmetric matrices.
+
+Weights must be finite and non-negative. Missing pairs are zero, duplicate pairs are
+rejected, and each group must appear at least once in each role. PatchSim does not
+normalize, symmetrize, or demographically adjust the matrix.
+
+`InteractionUnits` records the supplied weights' meaning. Examples include
+`contacts/person/day`, `partnerships/person/year`, or `dimensionless`. It is descriptive:
+the modeller must ensure that the interaction weights, spatial weights, transmission
+parameter, and simulation time unit are compatible.
+
+## Composition
+
+Let $W_{ij}$ be the spatial weight from focal patch $i$ to contributing patch $j$, and
+let $M_{ab}$ be the interaction weight from focal group $a$ to contributing group $b$.
+PatchSim computes:
+
+$$
+\lambda_{i,a}
+=
+\sum_j \sum_b
+W_{ij} M_{ab}
+\frac{I_{j,b}}{N_{j,b}}.
+$$
+
+A zero-population contributor has prevalence zero. For one patch, the spatial factor is
+one. For multiple patches, the existing `NetworkFile` rules apply, including zero
+spatial pressure when no network is supplied.
+
+This equation assumes spatial and group mixing are separable and that the same group
+matrix applies in every patch. If, for example, occupational mixing differs materially
+by district, a single shared matrix is not an adequate representation.
+
+## Validation
+
+Run validation before simulation:
+
+```bash
+patchsim validate -c config.yaml
+patchsim validate -c config.yaml --json > interaction-validation.json
+```
+
+The JSON result records:
+
+- group labels and ordering;
+- declared interaction units;
+- SHA-256 of the exact interaction file;
+- spatial and interaction row-sum ranges; and
+- maximum local reciprocity residual.
+
+For groups $a$ and $b$ in patch $i$, the reported residual compares:
+
+$$
+x = N_{i,a}M_{ab},
+\qquad
+y = N_{i,b}M_{ba},
+\qquad
+r = \frac{|x-y|}{\max(x,y)}.
+$$
+
+When $x=y=0$, $r=0$. Reciprocity is diagnostic only: it is expected for matrices
+representing reciprocal person-to-person contacts, but not necessarily for directed
+exposure coefficients or other proxies.
+
+For a proxy matrix, retain its derivation and assumptions with the input files. Compare
+results under defensible alternative matrices; successful numeric validation does not
+validate the proxy.
+
+## Worked example
+
+This one-patch SIR example uses illustrative `higher_contact` and `general`
+groups. The interaction values are not estimates for a specific population.
+
+```text
+group-example/
+  config.yaml
+  data/
+    patches.csv
+    groups.csv
+    seeds.csv
+    interactions.csv
+```
+
+`data/patches.csv`:
+
+```csv
+patch,population
+community,1000
+```
+
+`data/groups.csv`:
+
+```csv
+patch,group,population
+community,higher_contact,200
+community,general,800
+```
+
+`data/seeds.csv`:
+
+```csv
+patch,group,S,I,R
+community,higher_contact,199,1,0
+community,general,800,0,0
+```
+
+`data/interactions.csv`:
+
+```csv
+focal_group,contributor_group,weight
+higher_contact,higher_contact,8
+higher_contact,general,4
+general,higher_contact,1
+general,general,3
+```
+
+`config.yaml`:
+
+```yaml
+ModelName: group-example
+PatchFile: data/patches.csv
+GroupFile: data/groups.csv
+InteractionFile: data/interactions.csv
+InteractionUnits: contacts/person/day
+SeedFile: data/seeds.csv
+NetworkFile: null
+OutputDir: output/group-example
+
+TMax: 61
+Solver: ode
+TimeStep: 1.0
+
+compartments: [S, I, R]
+
+Parameters:
+  beta: 0.03
+  gamma: 0.1
+
+Transitions:
+  "S -> I": "beta"
+  "I -> R": "gamma * I"
+```
+
+Here `beta` is transmission probability per contact and `gamma` is per day.
+From `group-example/`, validate and run:
+
+```bash
+patchsim validate -c config.yaml
+patchsim validate -c config.yaml --json > interaction-validation.json
+patchsim run -c config.yaml --json > run-summary.json
+```
+
+From a source checkout, replace `patchsim` with `uv run patchsim`. The group order
+makes `I_0_0` the infectious `higher_contact` population and `I_0_1` the
+infectious `general` population.
+
+At time zero, infectious prevalence is `1 / 200 = 0.005` in `higher_contact`
+and zero in `general`. The initial pressures are:
+
+$$
+\lambda_{\mathrm{higher}} = 8(0.005) + 4(0) = 0.04,
+$$
+
+$$
+\lambda_{\mathrm{general}} = 1(0.005) + 3(0) = 0.005.
+$$
+
+Initial infection flows are therefore `0.03(199)(0.04) = 0.2388` and
+`0.03(800)(0.005) = 0.12`. These calculations verify orientation and units;
+they do not validate the illustrative interaction values.
+
+## Outputs and limits
+
+Ungrouped columns remain unchanged, such as `I_0`. Grouped columns use
+`COMPARTMENT_PATCH_GROUP`, such as `I_0_1`. Patch indices follow `PatchFile`; group
+indices follow `GroupFile`. Plots keep one panel per patch and label lines with both the
+compartment and group.
+
+The current feature supports one grouping axis and one shared, static interaction
+matrix. Patch-specific matrices, time-varying interactions, group-specific mobility,
+multiple simultaneous group axes, and automatic interaction generators are not
+implemented. `PatchParameters` still applies to every group within its patch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ version, and validate every configuration before running it.
 - [Configuration](configuration.md): field names, file contracts, and expressions.
 - [CLI reference](cli-reference.md): commands, output streams, and exit behavior.
 - [Mathematical model](mathematical-model.md): transition and network equations.
+- [Group stratification](group-stratification.md): custom groups and interaction matrices.
 - [Contact generation](contact-generation.md): spatial kernels, units, and validation.
 - [Results](results.md): output paths, column naming, and rerun behavior.
 
@@ -39,6 +40,7 @@ cli-reference.md
 mathematical-model.md
 rate-multiplication.md
 network-design.md
+group-stratification.md
 contact-generation.md
 simulation-workflow.md
 results.md

--- a/docs/mathematical-model.md
+++ b/docs/mathematical-model.md
@@ -107,6 +107,27 @@ $$
 Weights are not probabilities unless the input author makes them so. PatchSim
 does not normalize $W$.
 
+## Grouped infectious pressure
+
+An optional categorical group axis divides each patch population into modeller-defined
+strata. Let $M_{ab}$ be the supplied interaction weight from focal group $a$ to
+infectious contributor group $b$. The grouped runtime computes:
+
+$$
+\lambda_{i,a}(t)
+=
+\sum_{j=1}^{n}\sum_{b=1}^{g}
+W_{ij}M_{ab}\frac{I_{j,b}(t)}{N_{j,b}(t)}.
+$$
+
+For a single patch, $W_{11}=1$ for this calculation. A contributor stratum with zero
+population contributes zero. The infection flow is $\beta S_{i,a}\lambda_{i,a}$ under
+the built-in network infection rule.
+
+This is a separable spatial/group mixing assumption. `InteractionUnits` records the
+meaning of $M$; PatchSim does not normalize it or infer compatible units for $\beta$.
+See [Group stratification](group-stratification.md) for input and validation contracts.
+
 ## Other built-in templates
 
 The CLI can scaffold these transition structures:

--- a/docs/results.md
+++ b/docs/results.md
@@ -67,12 +67,22 @@ B,500
 `I_0` is infectious population in patch `A`, and `I_1` is infectious population
 in patch `B`.
 
+Grouped runs add the zero-based group index:
+
+```csv
+time,S_0_0,I_0_0,R_0_0,S_0_1,I_0_1,R_0_1
+```
+
+`COMPARTMENT_PATCH_GROUP` follows `PatchFile` and `GroupFile` ordering. The JSON
+validation and run summaries include the ordered `groups` list.
+
 Compartment values are floating point for both built-in solvers. The discrete
 solver is deterministic explicit Euler, not an integer-state method.
 
 ## Plot
 
-The PNG contains one subplot per patch and one line per configured compartment.
+The PNG contains one subplot per patch. Ungrouped plots have one line per
+compartment; grouped plots have one line per compartment/group combination.
 Subplot titles use patch identifiers from `PatchFile`. Axes are numeric time and
 compartment count.
 

--- a/src/patchsim/cli.py
+++ b/src/patchsim/cli.py
@@ -61,11 +61,18 @@ def _cmd_validate(config_path: str, *, json_output: bool = False, schema: bool =
         return get_config_schema()
 
     config = load_config(config_path)
-    _net, _y0, patches, num_patches = setup_simulation(config)
+    net, _y0, patches, num_patches = setup_simulation(config)
     if not json_output:
         print(f"Configuration is valid: {config_path}")
+        if net.groups:
+            diagnostics = net.interaction_diagnostics
+            print(
+                "Interaction diagnostics: "
+                f"units={diagnostics['units']}, "
+                f"max reciprocity residual={diagnostics['max_local_reciprocity_residual']:.6g}"
+            )
     if json_output:
-        return {
+        result = {
             "ok": True,
             "config": config_path,
             "model_name": config.get("ModelName"),
@@ -74,6 +81,15 @@ def _cmd_validate(config_path: str, *, json_output: bool = False, schema: bool =
             "solver": config["Solver"],
             "time_step": config["TimeStep"],
         }
+        if net.groups:
+            result.update(
+                {
+                    "num_groups": net.num_groups,
+                    "groups": net.groups,
+                    "interaction": net.interaction_diagnostics,
+                }
+            )
+        return result
     return None
 
 

--- a/src/patchsim/core/model.py
+++ b/src/patchsim/core/model.py
@@ -119,22 +119,57 @@ class CompartmentalModel:
 class NetworkModel:
     """Network model for multi-patch simulations."""
 
-    def __init__(self, base_model: CompartmentalModel, num_patches: int, network_matrix: list[list[float]]):
+    def __init__(
+        self,
+        base_model: CompartmentalModel,
+        num_patches: int,
+        network_matrix: list[list[float]],
+        groups: list[str] | None = None,
+        interaction_matrix: list[list[float]] | None = None,
+    ):
         """Initialize the network model."""
         self.base_model = base_model
         self.num_patches = num_patches
         self.network = network_matrix
-        self.all_compartments = [f"{c}_{i}" for i in range(num_patches) for c in base_model.compartments]
+        self.groups = list(groups or [])
+        self.num_groups = len(self.groups) if self.groups else 1
+        if len(set(self.groups)) != len(self.groups):
+            raise ValueError("Group labels must be unique.")
+        if interaction_matrix is not None and not self.groups:
+            raise ValueError("An interaction matrix requires group labels.")
+        self.interaction = np.asarray(
+            interaction_matrix if interaction_matrix is not None else [[1.0]],
+            dtype=float,
+        )
+        if self.interaction.shape != (self.num_groups, self.num_groups):
+            raise ValueError(
+                f"Interaction matrix must have shape {(self.num_groups, self.num_groups)}; "
+                f"received {self.interaction.shape}."
+            )
+        self.all_compartments = [
+            self.state_key(c, patch_idx, group_idx)
+            for patch_idx in range(num_patches)
+            for group_idx in range(self.num_groups)
+            for c in base_model.compartments
+        ]
 
-    def get_patch_state(self, full_state: Dict[str, float], patch_idx: int) -> Dict[str, float]:
-        """Get state for a specific patch."""
-        return {c: full_state[f"{c}_{patch_idx}"] for c in self.base_model.compartments}
+    def state_key(self, compartment: str, patch_idx: int, group_idx: int = 0) -> str:
+        """Return the internal state key for one compartment stratum."""
+        if self.groups:
+            return f"{compartment}_{patch_idx}_{group_idx}"
+        return f"{compartment}_{patch_idx}"
+
+    def get_patch_state(self, full_state: Dict[str, float], patch_idx: int, group_idx: int = 0) -> Dict[str, float]:
+        """Get compartment state for a patch and optional group."""
+        return {c: full_state[self.state_key(c, patch_idx, group_idx)] for c in self.base_model.compartments}
 
     def get_patch_population(self, state: Dict[str, float]) -> float:
         """Get total population for a patch."""
         return sum(state[c] for c in self.base_model.compartments)
 
-    def compute_force_of_infection(self, full_state: dict[str, float], infected_compartment: str = "I") -> list[float]:
+    def compute_force_of_infection(
+        self, full_state: dict[str, float], infected_compartment: str = "I"
+    ) -> list[float] | list[list[float]]:
         """Compute force of infection for each patch (per-capita rate, before beta scaling).
 
         Args:
@@ -142,26 +177,23 @@ class NetworkModel:
             infected_compartment: Name of the compartment representing infected individuals
 
         Returns:
-            List of per-capita forces of infection (model_runner applies beta * FOI * S)
+            Per-capita forces by patch, or by patch and group for grouped models.
         """
-        lambdas = []
+        forces = np.zeros((self.num_patches, self.num_groups), dtype=float)
         for i in range(self.num_patches):
-            if self.num_patches == 1:
-                # Single patch case: infected proportion
-                patch_state = self.get_patch_state(full_state, 0)
-                infected = patch_state[infected_compartment]
-                total_pop = self.get_patch_population(patch_state)
-                force = infected / total_pop if total_pop > 0 else 0
-            else:
-                # Multi-patch case: network-weighted infected proportion
-                force = 0
+            for group_i in range(self.num_groups):
                 for j in range(self.num_patches):
-                    patch_state_j = self.get_patch_state(full_state, j)
-                    infected_j = patch_state_j[infected_compartment]
-                    pop_j = self.get_patch_population(patch_state_j)
-                    force += self.network[i][j] * (infected_j / pop_j if pop_j > 0 else 0)
-            lambdas.append(force)
-        return lambdas
+                    spatial_weight = 1.0 if self.num_patches == 1 else self.network[i][j]
+                    for group_j in range(self.num_groups):
+                        interaction_weight = self.interaction[group_i][group_j]
+                        contributor_state = self.get_patch_state(full_state, j, group_j)
+                        infected = contributor_state[infected_compartment]
+                        population = self.get_patch_population(contributor_state)
+                        prevalence = infected / population if population > 0 else 0.0
+                        forces[i, group_i] += spatial_weight * interaction_weight * prevalence
+        if self.groups:
+            return forces.tolist()
+        return forces[:, 0].tolist()
 
     def _adjust_infection_rate(
         self,
@@ -169,10 +201,9 @@ class NetworkModel:
         original_rate_expr: Any,
         rate: float,
         patch_state: dict[str, float],
-        lambdas: list[float],
-        patch_idx: int,
+        force_of_infection: float,
         is_infection_transition: bool,
-        has_network: bool,
+        has_mixing: bool,
     ) -> float:
         """Adjust infection rate for network-mediated FOI.
 
@@ -181,24 +212,23 @@ class NetworkModel:
             original_rate_expr: Original rate expression from transition definition
             rate: Computed rate from base model
             patch_state: Current state for the patch
-            lambdas: Force of infection for each patch
-            patch_idx: Current patch index
+            force_of_infection: Force of infection for the current stratum
             is_infection_transition: Whether this is an infection transition
-            has_network: Whether multi-patch network exists
+            has_mixing: Whether spatial or group mixing is active
 
         Returns:
             Adjusted rate incorporating network FOI if applicable
         """
-        if is_infection_transition and has_network:
+        if is_infection_transition and has_mixing:
             # Network case: Apply network FOI (lambdas already computed)
             # Check if original expression includes beta term
             beta = patch_params.get("beta", 1.0)
             if isinstance(original_rate_expr, str) and re.search(r"\bbeta\b", original_rate_expr):
                 # Rate expression includes beta; apply network FOI correction
-                adjusted_rate = beta * patch_state["S"] * lambdas[patch_idx]
+                adjusted_rate = beta * patch_state["S"] * force_of_infection
             else:
                 # Rate is already computed; apply FOI scaling
-                adjusted_rate = rate * lambdas[patch_idx] if patch_state["S"] > 0 else 0
+                adjusted_rate = rate * force_of_infection if patch_state["S"] > 0 else 0
         else:
             # Single patch or non-infection transition: use rate as-is
             adjusted_rate = rate
@@ -211,62 +241,53 @@ class NetworkModel:
         # Compute network-mediated force of infection for each patch
         lambdas = self.compute_force_of_infection(state)
 
-        # Process each patch
+        # Process each patch and optional group.
         for i in range(self.num_patches):
-            # Get state for this patch
-            patch_state = self.get_patch_state(state, i)
+            for group_idx in range(self.num_groups):
+                patch_state = self.get_patch_state(state, i, group_idx)
 
-            # Resolve patch parameters using canonical patch ordering when available.
-            if hasattr(self, "patch_parameters"):
-                patch_name = None
-                if hasattr(self, "patch_names") and i < len(self.patch_names):
-                    patch_name = self.patch_names[i]
-                elif self.patch_parameters:
-                    import logging
+                # Resolve patch parameters using canonical patch ordering when available.
+                if hasattr(self, "patch_parameters"):
+                    patch_name = None
+                    if hasattr(self, "patch_names") and i < len(self.patch_names):
+                        patch_name = self.patch_names[i]
+                    elif self.patch_parameters:
+                        import logging
 
-                    logger = logging.getLogger(__name__)
-                    logger.warning(
-                        "patch_parameters defined but patch_names not set; "
-                        "patch-specific parameters will be ignored for patch %d",
-                        i,
+                        logger = logging.getLogger(__name__)
+                        logger.warning(
+                            "patch_parameters defined but patch_names not set; "
+                            "patch-specific parameters will be ignored for patch %d",
+                            i,
+                        )
+                    patch_params = {**self.base_model.parameters, **self.patch_parameters.get(patch_name, {})}
+                else:
+                    patch_params = self.base_model.parameters
+
+                rates = self.base_model.compute_rates(patch_state, parameters=patch_params)
+                force = lambdas[i][group_idx] if self.groups else lambdas[i]
+
+                for transition in self.base_model.transitions:
+                    transition_label = transition["transition"]
+                    source, target = [p.strip() for p in transition_label.split("->")]
+                    rate = rates[transition_label]
+                    original_rate_expr = transition.get("rate", "")
+
+                    infection_compartments = set(getattr(self, "infection_compartments", {"I", "E"}))
+                    is_infection_transition = source == "S" and target in infection_compartments
+                    has_mixing = self.num_patches > 1 or bool(self.groups)
+                    adjusted_rate = self._adjust_infection_rate(
+                        patch_params,
+                        original_rate_expr,
+                        rate,
+                        patch_state,
+                        force,
+                        is_infection_transition,
+                        has_mixing,
                     )
-                patch_params = {**self.base_model.parameters, **self.patch_parameters.get(patch_name, {})}
-            else:
-                patch_params = self.base_model.parameters
 
-            # Compute rates with patch-specific parameters without mutating shared state
-            rates = self.base_model.compute_rates(patch_state, parameters=patch_params)
-
-            # Update derivatives based on rates, applying network-mediated FOI to infection transitions
-            for transition in self.base_model.transitions:
-                transition_label = transition["transition"]
-                source, target = [p.strip() for p in transition_label.split("->")]
-                rate = rates[transition_label]
-                original_rate_expr = transition.get("rate", "")
-
-                # Apply network-mediated FOI to susceptible-to-infection transitions.
-                # Allow model-level override via `infection_compartments` attribute.
-                infection_compartments = set(getattr(self, "infection_compartments", {"I", "E"}))
-                is_infection_transition = source == "S" and target in infection_compartments
-
-                has_network = self.num_patches > 1 and self.network is not None
-
-                # Use shared helper to adjust infection rate for network FOI
-                adjusted_rate = self._adjust_infection_rate(
-                    patch_params,
-                    original_rate_expr,
-                    rate,
-                    patch_state,
-                    lambdas,
-                    i,
-                    is_infection_transition,
-                    has_network,
-                )
-
-                # Decrease source compartment
-                derivatives[f"{source}_{i}"] -= adjusted_rate
-                # Increase target compartment
-                derivatives[f"{target}_{i}"] += adjusted_rate
+                    derivatives[self.state_key(source, i, group_idx)] -= adjusted_rate
+                    derivatives[self.state_key(target, i, group_idx)] += adjusted_rate
 
         return derivatives
 

--- a/src/patchsim/core/model.py
+++ b/src/patchsim/core/model.py
@@ -2,6 +2,7 @@
 Core model implementation for compartmental models.
 """
 
+import logging
 import re
 from typing import Any, Callable, Dict
 
@@ -141,6 +142,7 @@ class NetworkModel:
             interaction_matrix if interaction_matrix is not None else [[1.0]],
             dtype=float,
         )
+        self._patch_names_warning_emitted = False
         if self.interaction.shape != (self.num_groups, self.num_groups):
             raise ValueError(
                 f"Interaction matrix must have shape {(self.num_groups, self.num_groups)}; "
@@ -179,18 +181,16 @@ class NetworkModel:
         Returns:
             Per-capita forces by patch, or by patch and group for grouped models.
         """
-        forces = np.zeros((self.num_patches, self.num_groups), dtype=float)
-        for i in range(self.num_patches):
-            for group_i in range(self.num_groups):
-                for j in range(self.num_patches):
-                    spatial_weight = 1.0 if self.num_patches == 1 else self.network[i][j]
-                    for group_j in range(self.num_groups):
-                        interaction_weight = self.interaction[group_i][group_j]
-                        contributor_state = self.get_patch_state(full_state, j, group_j)
-                        infected = contributor_state[infected_compartment]
-                        population = self.get_patch_population(contributor_state)
-                        prevalence = infected / population if population > 0 else 0.0
-                        forces[i, group_i] += spatial_weight * interaction_weight * prevalence
+        prevalence = np.zeros((self.num_patches, self.num_groups), dtype=float)
+        for patch_idx in range(self.num_patches):
+            for group_idx in range(self.num_groups):
+                contributor_state = self.get_patch_state(full_state, patch_idx, group_idx)
+                population = self.get_patch_population(contributor_state)
+                if population > 0:
+                    prevalence[patch_idx, group_idx] = contributor_state[infected_compartment] / population
+
+        spatial = np.ones((1, 1), dtype=float) if self.num_patches == 1 else np.asarray(self.network, dtype=float)
+        forces = spatial @ prevalence @ self.interaction.T
         if self.groups:
             return forces.tolist()
         return forces[:, 0].tolist()
@@ -240,6 +240,8 @@ class NetworkModel:
 
         # Compute network-mediated force of infection for each patch
         lambdas = self.compute_force_of_infection(state)
+        infection_compartments = set(getattr(self, "infection_compartments", {"I", "E"}))
+        has_mixing = self.num_patches > 1 or bool(self.groups)
 
         # Process each patch and optional group.
         for i in range(self.num_patches):
@@ -251,11 +253,9 @@ class NetworkModel:
                     patch_name = None
                     if hasattr(self, "patch_names") and i < len(self.patch_names):
                         patch_name = self.patch_names[i]
-                    elif self.patch_parameters:
-                        import logging
-
-                        logger = logging.getLogger(__name__)
-                        logger.warning(
+                    elif self.patch_parameters and not self._patch_names_warning_emitted:
+                        self._patch_names_warning_emitted = True
+                        logging.getLogger(__name__).warning(
                             "patch_parameters defined but patch_names not set; "
                             "patch-specific parameters will be ignored for patch %d",
                             i,
@@ -273,9 +273,7 @@ class NetworkModel:
                     rate = rates[transition_label]
                     original_rate_expr = transition.get("rate", "")
 
-                    infection_compartments = set(getattr(self, "infection_compartments", {"I", "E"}))
                     is_infection_transition = source == "S" and target in infection_compartments
-                    has_mixing = self.num_patches > 1 or bool(self.groups)
                     adjusted_rate = self._adjust_infection_rate(
                         patch_params,
                         original_rate_expr,

--- a/src/patchsim/core/model_runner.py
+++ b/src/patchsim/core/model_runner.py
@@ -15,33 +15,7 @@ class Model:
     def construct_ode(self):
         def rhs(y, t):
             state = {v: y[i] for i, v in enumerate(self.all_vars)}
-            dydt = {v: 0.0 for v in self.all_vars}
-
-            # Compute network-based force of infection (per-capita, without beta)
-            lambdas = self.network.compute_force_of_infection(state)
-
-            # Apply transitions for all patches
-            for i in range(self.network.num_patches):
-                patch_state = {c: state[f"{c}_{i}"] for c in self.compartments}
-                rates = self.network.base_model.compute_rates(patch_state)
-                patch_params = self.network.base_model.parameters
-
-                for key, rate in rates.items():
-                    src, tgt = [p.strip() for p in key.split("->")]
-
-                    # Determine if this is an infection transition
-                    infection_compartments = set(getattr(self.network, "infection_compartments", {"I", "E"}))
-                    is_infection_transition = src == "S" and tgt in infection_compartments
-
-                    # Use network helper to apply FOI adjustment consistently
-                    has_network = self.network.num_patches > 1 and self.network.network is not None
-                    adjusted_rate = self.network._adjust_infection_rate(
-                        patch_params, key, rate, patch_state, lambdas, i, is_infection_transition, has_network
-                    )
-
-                    dydt[f"{src}_{i}"] -= adjusted_rate
-                    dydt[f"{tgt}_{i}"] += adjusted_rate
-
+            dydt = self.network.compute_derivatives(state)
             return [dydt[v] for v in self.all_vars]
 
         return rhs
@@ -59,4 +33,12 @@ class Model:
     def visualize(self, t, results, patches, outdir, model_name):
         from patchsim.utils.viz import plot_patch_subplots
 
-        plot_patch_subplots(t, results, patches, outdir, model_name, compartments=self.compartments)
+        plot_patch_subplots(
+            t,
+            results,
+            patches,
+            outdir,
+            model_name,
+            compartments=self.compartments,
+            groups=self.network.groups,
+        )

--- a/src/patchsim/core/simulation.py
+++ b/src/patchsim/core/simulation.py
@@ -279,14 +279,16 @@ def _load_groups(
         raise ValueError(f"GroupFile ({path}) has no groups for first patch '{patches[0]}'.")
     groups = list(first_patch_groups)
     expected_groups = set(groups)
+    rows_by_patch = {patch: rows for patch, rows in frame.groupby("patch", sort=False)}
     for patch in patches:
-        actual = set(frame.loc[frame["patch"] == patch, "group"])
+        patch_rows = rows_by_patch[patch]
+        actual = set(patch_rows["group"])
         if actual != expected_groups:
             raise ValueError(
                 f"GroupFile ({path}) groups for patch '{patch}' do not match the first patch "
                 f"(missing={sorted(expected_groups - actual)}, extra={sorted(actual - expected_groups)})."
             )
-        total = float(frame.loc[frame["patch"] == patch, "population"].sum())
+        total = float(patch_rows["population"].sum())
         if abs(total - populations[patch]) >= EPSILON:
             raise ValueError(
                 f"Group populations for patch '{patch}' sum to {total}, not PatchFile population {populations[patch]}."

--- a/src/patchsim/core/simulation.py
+++ b/src/patchsim/core/simulation.py
@@ -3,6 +3,7 @@ This module is reserved for reusable simulation utilities or wrappers.
 ODE and discrete simulation logic is implemented in core/model.py.
 """
 
+import hashlib
 import os
 import re
 from numbers import Real
@@ -59,6 +60,9 @@ def get_config_schema() -> dict[str, Any]:
             "PatchFile": {"type": "string"},
             "SeedFile": {"type": "string"},
             "NetworkFile": {"type": ["string", "null"]},
+            "GroupFile": {"type": "string"},
+            "InteractionFile": {"type": "string"},
+            "InteractionUnits": {"type": "string", "minLength": 1},
             "OutputDir": {"type": "string"},
             "ModelName": {"type": "string"},
             "TMax": {"type": "integer", "minimum": 1},
@@ -104,6 +108,11 @@ def get_config_schema() -> dict[str, Any]:
                 "minProperties": 1,
                 "additionalProperties": {"type": "string"},
             },
+        },
+        "dependentRequired": {
+            "GroupFile": ["InteractionFile", "InteractionUnits"],
+            "InteractionFile": ["GroupFile", "InteractionUnits"],
+            "InteractionUnits": ["GroupFile", "InteractionFile"],
         },
         "additionalProperties": True,
     }
@@ -177,7 +186,7 @@ def load_config(config_path: str) -> dict[str, Any]:
 
     # Resolve relative paths against the config file directory.
     cfg_dir = cfg_path.parent
-    for key in ["PatchFile", "SeedFile", "NetworkFile", "OutputDir"]:
+    for key in ["PatchFile", "SeedFile", "NetworkFile", "GroupFile", "InteractionFile", "OutputDir"]:
         val = config.get(key)
         if isinstance(val, str) and val.strip():
             p = Path(val).expanduser()
@@ -206,6 +215,173 @@ def get_run_settings(config: dict[str, Any]) -> tuple[str, int, float]:
     return solver, t_max, time_step
 
 
+def _numeric_values(frame: pd.DataFrame, columns: list[str], source: str) -> None:
+    """Convert selected columns to finite numbers in place."""
+    for column in columns:
+        try:
+            frame[column] = pd.to_numeric(frame[column], errors="raise")
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"{source} column '{column}' must contain only numbers.") from e
+        if not np.all(np.isfinite(frame[column].to_numpy(dtype=float))):
+            raise ValueError(f"{source} column '{column}' must contain only finite numbers.")
+
+
+def _load_groups(
+    config: dict[str, Any], patches: list[str], populations: dict[str, float]
+) -> tuple[list[str], dict[tuple[str, str], float]]:
+    """Load the optional patch-by-group population table."""
+    fields = ("GroupFile", "InteractionFile", "InteractionUnits")
+    present = [field for field in fields if config.get(field) is not None]
+    if present and len(present) != len(fields):
+        missing = [field for field in fields if config.get(field) is None]
+        raise ValueError(f"Grouped simulations require {list(fields)} together; missing {missing}.")
+    if not present:
+        return [], {}
+
+    units = config["InteractionUnits"]
+    if not isinstance(units, str) or not units.strip():
+        raise ValueError("'InteractionUnits' must be a non-empty unit description.")
+
+    path = config["GroupFile"]
+    header = pd.read_csv(path, nrows=0).columns
+    patch_col = next((c for c in header if c.lower() == "patch"), None)
+    group_col = next((c for c in header if c.lower() == "group"), None)
+    pop_col = next((c for c in header if c.lower() == "population"), None)
+    if patch_col is None or group_col is None or pop_col is None:
+        raise ValueError(f"GroupFile ({path}) must have 'patch', 'group', and 'population' columns.")
+
+    frame = pd.read_csv(
+        path,
+        dtype={patch_col: "string", group_col: "string"},
+        keep_default_na=False,
+    ).rename(columns={patch_col: "patch", group_col: "group", pop_col: "population"})
+    _numeric_values(frame, ["population"], f"GroupFile ({path})")
+    for column in ("patch", "group"):
+        values = frame[column].astype(str)
+        if any(not value or value != value.strip() for value in values):
+            raise ValueError(f"GroupFile ({path}) contains an empty or whitespace-padded {column} identifier.")
+        frame[column] = values
+    if (frame["population"] < 0).any():
+        raise ValueError(f"GroupFile ({path}) populations must be non-negative.")
+    if frame.duplicated(["patch", "group"]).any():
+        raise ValueError(f"GroupFile ({path}) contains duplicate patch/group pairs.")
+
+    patch_set = set(frame["patch"])
+    expected_patch_set = set(patches)
+    if patch_set != expected_patch_set:
+        raise ValueError(
+            f"GroupFile ({path}) patch identifiers do not match PatchFile "
+            f"(missing={sorted(expected_patch_set - patch_set)}, extra={sorted(patch_set - expected_patch_set)})."
+        )
+
+    first_patch_groups = frame.loc[frame["patch"] == patches[0], "group"].tolist()
+    if not first_patch_groups:
+        raise ValueError(f"GroupFile ({path}) has no groups for first patch '{patches[0]}'.")
+    groups = list(first_patch_groups)
+    expected_groups = set(groups)
+    for patch in patches:
+        actual = set(frame.loc[frame["patch"] == patch, "group"])
+        if actual != expected_groups:
+            raise ValueError(
+                f"GroupFile ({path}) groups for patch '{patch}' do not match the first patch "
+                f"(missing={sorted(expected_groups - actual)}, extra={sorted(actual - expected_groups)})."
+            )
+        total = float(frame.loc[frame["patch"] == patch, "population"].sum())
+        if abs(total - populations[patch]) >= EPSILON:
+            raise ValueError(
+                f"Group populations for patch '{patch}' sum to {total}, not PatchFile population {populations[patch]}."
+            )
+
+    group_populations = {
+        (row.patch, row.group): float(row.population)
+        for row in frame[["patch", "group", "population"]].itertuples(index=False)
+    }
+    return groups, group_populations
+
+
+def _load_interactions(
+    config: dict[str, Any],
+    groups: list[str],
+    patches: list[str],
+    group_populations: dict[tuple[str, str], float],
+    network_matrix: np.ndarray,
+) -> tuple[np.ndarray | None, dict[str, Any] | None]:
+    """Load a shared group interaction matrix and return validation diagnostics."""
+    if not groups:
+        return None, None
+
+    path = config["InteractionFile"]
+    required = ["focal_group", "contributor_group", "weight"]
+    header = pd.read_csv(path, nrows=0).columns.tolist()
+    missing = [column for column in required if column not in header]
+    if missing:
+        raise ValueError(f"InteractionFile ({path}) is missing columns: {missing}.")
+
+    frame = pd.read_csv(
+        path,
+        dtype={"focal_group": "string", "contributor_group": "string"},
+        keep_default_na=False,
+    )
+    _numeric_values(frame, ["weight"], f"InteractionFile ({path})")
+    for column in ("focal_group", "contributor_group"):
+        values = frame[column].astype(str)
+        if any(not value or value != value.strip() for value in values):
+            raise ValueError(f"InteractionFile ({path}) contains an empty or whitespace-padded {column}.")
+        frame[column] = values
+    if (frame["weight"] < 0).any():
+        raise ValueError(f"InteractionFile ({path}) weights must be non-negative.")
+    if frame.duplicated(["focal_group", "contributor_group"]).any():
+        raise ValueError(f"InteractionFile ({path}) contains duplicate group pairs.")
+
+    expected_groups = set(groups)
+    for column in ("focal_group", "contributor_group"):
+        actual = set(frame[column])
+        unknown = actual - expected_groups
+        if unknown:
+            raise ValueError(f"InteractionFile ({path}) contains unknown groups in {column}: {sorted(unknown)}.")
+        absent = expected_groups - actual
+        if absent:
+            raise ValueError(
+                f"InteractionFile ({path}) must mention every group in {column}; missing {sorted(absent)}."
+            )
+
+    group_idx = {group: idx for idx, group in enumerate(groups)}
+    matrix = np.zeros((len(groups), len(groups)), dtype=float)
+    for row in frame.itertuples(index=False):
+        matrix[group_idx[row.focal_group], group_idx[row.contributor_group]] = float(row.weight)
+
+    max_reciprocity_residual = 0.0
+    for patch in patches:
+        for focal in groups:
+            for contributor in groups:
+                i = group_idx[focal]
+                j = group_idx[contributor]
+                forward = group_populations[(patch, focal)] * matrix[i, j]
+                reverse = group_populations[(patch, contributor)] * matrix[j, i]
+                denominator = max(forward, reverse)
+                residual = abs(forward - reverse) / denominator if denominator > 0 else 0.0
+                max_reciprocity_residual = max(max_reciprocity_residual, residual)
+
+    interaction_row_sums = matrix.sum(axis=1)
+    effective_spatial_matrix = np.ones((1, 1), dtype=float) if len(patches) == 1 else network_matrix
+    spatial_row_sums = effective_spatial_matrix.sum(axis=1)
+    diagnostics = {
+        "units": config["InteractionUnits"].strip(),
+        "sha256": hashlib.sha256(Path(path).read_bytes()).hexdigest(),
+        "interaction_row_sum": {
+            "min": float(interaction_row_sums.min()),
+            "max": float(interaction_row_sums.max()),
+        },
+        "spatial_row_sum": {
+            "min": float(spatial_row_sums.min()),
+            "max": float(spatial_row_sums.max()),
+        },
+        "max_local_reciprocity_residual": float(max_reciprocity_residual),
+        "reciprocity": "diagnostic_only",
+    }
+    return matrix, diagnostics
+
+
 def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, float], list, int]:
     """Set up the simulation model and initial conditions."""
     # Load patch data (accept either case for the 'patch'/'population' columns)
@@ -219,21 +395,36 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
         )
     patch_df = pd.read_csv(config["PatchFile"], converters={patch_col: str})
     patches = patch_df[patch_col].tolist()
+    if not patches:
+        raise ValueError(f"PatchFile ({config['PatchFile']}) must contain at least one patch.")
     if any(not patch.strip() for patch in patches):
         raise ValueError(f"PatchFile ({config['PatchFile']}) contains an empty patch identifier.")
+    if len(set(patches)) != len(patches):
+        raise ValueError(f"PatchFile ({config['PatchFile']}) contains duplicate patch identifiers.")
     populations = patch_df.set_index(patch_col)[pop_col].to_dict()
 
     for p, pop in populations.items():
-        if pop <= 0:
+        if not isinstance(pop, Real) or not np.isfinite(pop) or pop <= 0:
             raise ValueError(
                 f"Invalid population in {config['PatchFile']}: patch '{p}' has population {pop}.\n"
                 "Population must be a positive number (> 0).\n"
                 "Please correct the population value in your patch file."
             )
 
+    groups, group_populations = _load_groups(config, patches, populations)
+
     # Load seed data
-    seed_df = pd.read_csv(config["SeedFile"], converters={"patch": str})
-    seed_compartments = [col for col in seed_df.columns if col != "patch"]
+    seed_converters = {"patch": str}
+    if groups:
+        seed_converters["group"] = str
+    seed_df = pd.read_csv(config["SeedFile"], converters=seed_converters, keep_default_na=False)
+    if groups and "group" not in seed_df.columns:
+        raise ValueError(f"SeedFile ({config['SeedFile']}) must include a 'group' column for grouped simulations.")
+    if not groups and "group" in seed_df.columns:
+        raise ValueError("SeedFile includes 'group', but GroupFile and InteractionFile are not configured.")
+    identifier_columns = {"patch", "group"} if groups else {"patch"}
+    seed_compartments = [col for col in seed_df.columns if col not in identifier_columns]
+    _numeric_values(seed_df, seed_compartments, f"SeedFile ({config['SeedFile']})")
 
     configured_compartments = config.get("compartments", config.get("Compartments"))
     if configured_compartments is None:
@@ -255,6 +446,17 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
                 "Please ensure the SeedFile has columns matching your config compartments."
             )
 
+    if groups:
+        if seed_df.duplicated(["patch", "group"]).any():
+            raise ValueError(f"SeedFile ({config['SeedFile']}) contains duplicate patch/group pairs.")
+        expected_pairs = set(group_populations)
+        actual_pairs = set(zip(seed_df["patch"], seed_df["group"], strict=True))
+        if actual_pairs != expected_pairs:
+            raise ValueError(
+                f"SeedFile ({config['SeedFile']}) patch/group coverage is incomplete "
+                f"(missing={sorted(expected_pairs - actual_pairs)}, extra={sorted(actual_pairs - expected_pairs)})."
+            )
+
     for _, row in seed_df.iterrows():
         patch = row["patch"]
         if patch not in populations:
@@ -263,6 +465,9 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
                 f"Known patches from PatchFile: {sorted(populations.keys())}\n"
                 "Please ensure all patches in SeedFile match PatchFile."
             )
+        group = row["group"] if groups else None
+        if groups and group not in groups:
+            raise ValueError(f"Unknown group '{group}' in SeedFile ({config['SeedFile']}).")
         total = sum(row[c] for c in compartments)
         if not all(row[c] >= 0 for c in compartments):
             neg_comps = [c for c in compartments if row[c] < 0]
@@ -271,9 +476,12 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
                 f"Compartments with negative values: {neg_comps}\n"
                 "All seed values must be non-negative."
             )
-        if abs(total - populations[patch]) >= EPSILON:
+        expected_population = group_populations[(patch, group)] if groups else populations[patch]
+        if abs(total - expected_population) >= EPSILON:
+            stratum = f", group '{group}'" if groups else ""
             raise ValueError(
-                f"Seed mismatch for patch '{patch}': seed sum ({total}) != population ({populations[patch]}).\n"
+                f"Seed mismatch for patch '{patch}'{stratum}: "
+                f"seed sum ({total}) != population ({expected_population}).\n"
                 f"Seed compartments: {dict((c, row[c]) for c in compartments)}\n"
                 "Ensure seed values sum exactly to the patch population."
             )
@@ -317,6 +525,14 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
                     "Network weights must be non-negative. Please correct your network file."
                 )
             network_matrix[i, j] = row["weight"]
+
+    interaction_matrix, interaction_diagnostics = _load_interactions(
+        config,
+        groups,
+        patches,
+        group_populations,
+        network_matrix,
+    )
 
     # Set up model
     global_params = config.get("Parameters", {})
@@ -382,19 +598,28 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
     # Initialize the base model (will hold default/global transitions)
     base_model = CompartmentalModel(compartments=compartments, parameters=global_params, transitions=transitions)
 
+    # Create network model
+    net = NetworkModel(
+        base_model=base_model,
+        num_patches=num_patches,
+        network_matrix=network_matrix,
+        groups=groups,
+        interaction_matrix=interaction_matrix,
+    )
+
     # Prepare initial conditions
     patch_idx = {p: i for i, p in enumerate(patches)}
+    group_idx = {group: i for i, group in enumerate(groups)}
     y0 = {}
     for _, row in seed_df.iterrows():
         for c in compartments:
-            y0[f"{c}_{patch_idx[row['patch']]}"] = row[c]
-
-    # Create network model
-    net = NetworkModel(base_model=base_model, num_patches=num_patches, network_matrix=network_matrix)
+            group_position = group_idx[row["group"]] if groups else 0
+            y0[net.state_key(c, patch_idx[row["patch"]], group_position)] = row[c]
 
     # Attach per-patch parameters to the network model
     net.patch_parameters = patch_params
     net.patch_names = patches
+    net.interaction_diagnostics = interaction_diagnostics
 
     return net, y0, patches, num_patches
 
@@ -447,13 +672,14 @@ def run_simulation(
         plots_dir,
         model_name,
         compartments=list(net.base_model.compartments),
+        groups=net.groups,
         solver=solver,
     )
 
     plot_path = os.path.join(plots_dir, f"patch_timeseries_{model_name}_{solver}.png")
     logger.info(f"Saved all patch subplots to {plot_path}")
 
-    return {
+    summary = {
         "model_name": model_name,
         "output_dir": config["OutputDir"],
         "csv_path": csv_path,
@@ -464,3 +690,6 @@ def run_simulation(
         "solver": solver,
         "time_step": time_step,
     }
+    if net.groups:
+        summary.update({"num_groups": net.num_groups, "groups": net.groups})
+    return summary

--- a/src/patchsim/utils/logger.py
+++ b/src/patchsim/utils/logger.py
@@ -54,6 +54,10 @@ def setup_logger(model_name, config, num_patches, patches, base_model):
     logger.info(f"PatchFile: {config['PatchFile']}")
     logger.info(f"SeedFile: {config['SeedFile']}")
     logger.info(f"NetworkFile: {config['NetworkFile']}")
+    if "GroupFile" in config:
+        logger.info(f"GroupFile: {config['GroupFile']}")
+        logger.info(f"InteractionFile: {config['InteractionFile']}")
+        logger.info(f"InteractionUnits: {config['InteractionUnits']}")
     logger.info(f"OutputDir: {config['OutputDir']}")
     logger.info(f"Solver: {config['Solver']}")
     logger.info(f"TimeStep: {config['TimeStep']}")

--- a/src/patchsim/utils/viz.py
+++ b/src/patchsim/utils/viz.py
@@ -27,7 +27,14 @@ def plot_patch_subplots(
     axes = axes.flatten() if n > 1 else [axes]
     for i, patch in enumerate(patches):
         ax = axes[i]
-        comps = compartments or [k[: -len(f"_{i}")] for k in out_ode if k.endswith(f"_{i}")]
+        if compartments is not None:
+            comps = compartments
+        elif groups:
+            suffix = f"_{i}_0"
+            comps = [key[: -len(suffix)] for key in out_ode if key.endswith(suffix)]
+        else:
+            suffix = f"_{i}"
+            comps = [key[: -len(suffix)] for key in out_ode if key.endswith(suffix)]
         if groups:
             for group_idx, group in enumerate(groups):
                 for compartment in comps:

--- a/src/patchsim/utils/viz.py
+++ b/src/patchsim/utils/viz.py
@@ -12,6 +12,7 @@ def plot_patch_subplots(
     model_name,
     patch_parameters=None,
     compartments=None,
+    groups=None,
     solver="ode",
 ):
     """
@@ -26,10 +27,18 @@ def plot_patch_subplots(
     axes = axes.flatten() if n > 1 else [axes]
     for i, patch in enumerate(patches):
         ax = axes[i]
-        # Plot the model's actual compartments; fall back to those present for this patch.
         comps = compartments or [k[: -len(f"_{i}")] for k in out_ode if k.endswith(f"_{i}")]
-        for c in comps:
-            ax.plot(t_range, out_ode[f"{c}_{i}"], label=c)
+        if groups:
+            for group_idx, group in enumerate(groups):
+                for compartment in comps:
+                    ax.plot(
+                        t_range,
+                        out_ode[f"{compartment}_{i}_{group_idx}"],
+                        label=f"{compartment} ({group})",
+                    )
+        else:
+            for compartment in comps:
+                ax.plot(t_range, out_ode[f"{compartment}_{i}"], label=compartment)
         solver_label = "ODE" if solver == "ode" else "Discrete"
         title = f"Patch {patch} ({solver_label})"
         if patch_parameters and patch in patch_parameters:

--- a/tests/test_group_stratification.py
+++ b/tests/test_group_stratification.py
@@ -1,0 +1,234 @@
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from patchsim.core.model import CompartmentalModel, NetworkModel
+from patchsim.core.simulation import load_config, setup_simulation
+
+
+def _write_grouped_project(tmp_path: Path) -> Path:
+    pd.DataFrame(
+        {
+            "patch": ["A", "B"],
+            "population": [200, 100],
+        }
+    ).to_csv(tmp_path / "patches.csv", index=False)
+    pd.DataFrame(
+        {
+            "patch": ["A", "A", "B", "B"],
+            "group": ["low", "high", "high", "low"],
+            "population": [100, 100, 0, 100],
+        }
+    ).to_csv(tmp_path / "groups.csv", index=False)
+    pd.DataFrame(
+        {
+            "patch": ["A", "A", "B", "B"],
+            "group": ["low", "high", "low", "high"],
+            "S": [99, 100, 100, 0],
+            "I": [1, 0, 0, 0],
+            "R": [0, 0, 0, 0],
+        }
+    ).to_csv(tmp_path / "seeds.csv", index=False)
+    pd.DataFrame(
+        {
+            "day": [0, 0, 0, 0],
+            "source": ["A", "A", "B", "B"],
+            "target": ["A", "B", "A", "B"],
+            "weight": [0.8, 0.2, 0.2, 0.8],
+        }
+    ).to_csv(tmp_path / "network.csv", index=False)
+    pd.DataFrame(
+        {
+            "focal_group": ["low", "low", "high", "high"],
+            "contributor_group": ["low", "high", "low", "high"],
+            "weight": [2.0, 1.0, 3.0, 4.0],
+        }
+    ).to_csv(tmp_path / "interactions.csv", index=False)
+
+    config = {
+        "ModelName": "groups",
+        "PatchFile": "patches.csv",
+        "GroupFile": "groups.csv",
+        "InteractionFile": "interactions.csv",
+        "InteractionUnits": "contacts/person/day",
+        "SeedFile": "seeds.csv",
+        "NetworkFile": "network.csv",
+        "OutputDir": "output",
+        "TMax": 3,
+        "Solver": "ode",
+        "TimeStep": 1,
+        "compartments": ["S", "I", "R"],
+        "Parameters": {"beta": 0.08, "gamma": 0.1},
+        "Transitions": {"S -> I": "beta", "I -> R": "gamma * I"},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+def test_setup_loads_generic_groups_and_diagnostics(tmp_path):
+    config_path = _write_grouped_project(tmp_path)
+    config = load_config(str(config_path))
+
+    net, y0, patches, num_patches = setup_simulation(config)
+
+    assert patches == ["A", "B"]
+    assert num_patches == 2
+    assert net.groups == ["low", "high"]
+    assert y0["I_0_0"] == 1
+    assert y0["S_1_0"] == 100
+    assert y0["S_1_1"] == 0
+    np.testing.assert_allclose(net.interaction, [[2.0, 1.0], [3.0, 4.0]])
+    np.testing.assert_allclose(net.compute_force_of_infection(y0), [[0.016, 0.024], [0.004, 0.006]])
+    assert net.interaction_diagnostics["units"] == "contacts/person/day"
+    assert (
+        net.interaction_diagnostics["sha256"]
+        == hashlib.sha256((tmp_path / "interactions.csv").read_bytes()).hexdigest()
+    )
+    assert net.interaction_diagnostics["reciprocity"] == "diagnostic_only"
+
+
+def test_force_of_infection_uses_focal_rows_and_zero_population_contributes_zero():
+    base = CompartmentalModel(
+        ["S", "I", "R"],
+        {"beta": 1.0, "gamma": 0.1},
+        [{"transition": "S->I", "rate": "beta"}, {"transition": "I->R", "rate": "gamma * I"}],
+    )
+    model = NetworkModel(
+        base,
+        num_patches=1,
+        network_matrix=[[0.0]],
+        groups=["low", "high", "absent"],
+        interaction_matrix=[
+            [2.0, 1.0, 100.0],
+            [3.0, 4.0, 100.0],
+            [0.0, 0.0, 0.0],
+        ],
+    )
+    state = {
+        "S_0_0": 90.0,
+        "I_0_0": 10.0,
+        "R_0_0": 0.0,
+        "S_0_1": 80.0,
+        "I_0_1": 20.0,
+        "R_0_1": 0.0,
+        "S_0_2": 0.0,
+        "I_0_2": 0.0,
+        "R_0_2": 0.0,
+    }
+
+    force = model.compute_force_of_infection(state)
+
+    np.testing.assert_allclose(force, [[0.4, 1.1, 0.0]])
+    derivatives = model.compute_derivatives(state)
+    assert derivatives["S_0_0"] == pytest.approx(-36.0)
+    assert derivatives["S_0_1"] == pytest.approx(-88.0)
+    assert all(np.isfinite(value) for value in derivatives.values())
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda path: pd.DataFrame(
+                {
+                    "patch": ["A", "A", "B"],
+                    "group": ["low", "high", "low"],
+                    "population": [100, 100, 100],
+                }
+            ).to_csv(path / "groups.csv", index=False),
+            "groups for patch 'B' do not match",
+        ),
+        (
+            lambda path: pd.DataFrame(
+                {
+                    "focal_group": ["low", "high"],
+                    "contributor_group": ["low", "low"],
+                    "weight": [1, 1],
+                }
+            ).to_csv(path / "interactions.csv", index=False),
+            "must mention every group in contributor_group",
+        ),
+        (
+            lambda path: pd.DataFrame(
+                {
+                    "focal_group": ["low", "low", "high", "other"],
+                    "contributor_group": ["low", "high", "low", "high"],
+                    "weight": [1, 1, 1, 1],
+                }
+            ).to_csv(path / "interactions.csv", index=False),
+            "unknown groups",
+        ),
+    ],
+)
+def test_group_input_coverage_is_validated(tmp_path, mutate, message):
+    config_path = _write_grouped_project(tmp_path)
+    mutate(tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        setup_simulation(load_config(str(config_path)))
+
+
+def test_group_fields_are_required_together(tmp_path):
+    config_path = _write_grouped_project(tmp_path)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    del config["InteractionUnits"]
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="require.*together"):
+        setup_simulation(load_config(str(config_path)))
+
+
+@pytest.mark.parametrize("solver", ["ode", "discrete"])
+def test_grouped_cli_validate_and_run(tmp_path, solver):
+    config_path = _write_grouped_project(tmp_path)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["Solver"] = solver
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    validate = subprocess.run(
+        ["patchsim", "validate", "-c", str(config_path), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert validate.returncode == 0, validate.stderr
+    validation = json.loads(validate.stdout)
+    assert validation["groups"] == ["low", "high"]
+    assert validation["num_groups"] == 2
+    assert validation["interaction"]["units"] == "contacts/person/day"
+
+    run = subprocess.run(
+        ["patchsim", "run", "-c", str(config_path), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert run.returncode == 0, run.stderr
+    summary = json.loads(run.stdout)
+    assert summary["groups"] == ["low", "high"]
+    output = pd.read_csv(summary["csv_path"])
+    assert output.columns.tolist() == [
+        "time",
+        "S_0_0",
+        "I_0_0",
+        "R_0_0",
+        "S_0_1",
+        "I_0_1",
+        "R_0_1",
+        "S_1_0",
+        "I_1_0",
+        "R_1_0",
+        "S_1_1",
+        "I_1_1",
+        "R_1_1",
+    ]
+    for patch_idx, group_totals in enumerate(([100, 100], [100, 0])):
+        for group_idx, expected_total in enumerate(group_totals):
+            columns = [f"{compartment}_{patch_idx}_{group_idx}" for compartment in ("S", "I", "R")]
+            np.testing.assert_allclose(output[columns].sum(axis=1), expected_total, atol=1e-8)
+    assert Path(summary["plot_path"]).is_file()

--- a/tests/test_group_stratification.py
+++ b/tests/test_group_stratification.py
@@ -10,6 +10,7 @@ import yaml
 
 from patchsim.core.model import CompartmentalModel, NetworkModel
 from patchsim.core.simulation import load_config, setup_simulation
+from patchsim.utils.viz import plot_patch_subplots
 
 
 def _write_grouped_project(tmp_path: Path) -> Path:
@@ -130,6 +131,47 @@ def test_force_of_infection_uses_focal_rows_and_zero_population_contributes_zero
     assert derivatives["S_0_0"] == pytest.approx(-36.0)
     assert derivatives["S_0_1"] == pytest.approx(-88.0)
     assert all(np.isfinite(value) for value in derivatives.values())
+
+
+def test_missing_patch_names_warning_is_emitted_once(caplog):
+    base = CompartmentalModel(
+        ["S", "I"],
+        {"beta": 0.1},
+        [{"transition": "S->I", "rate": "beta"}],
+    )
+    model = NetworkModel(base, num_patches=2, network_matrix=[[1.0, 0.0], [0.0, 1.0]])
+    model.patch_parameters = {"A": {"beta": 0.2}}
+    state = {"S_0": 99.0, "I_0": 1.0, "S_1": 100.0, "I_1": 0.0}
+
+    model.compute_derivatives(state)
+    model.compute_derivatives(state)
+
+    assert (
+        caplog.messages.count(
+            "patch_parameters defined but patch_names not set; patch-specific parameters will be ignored for patch 0"
+        )
+        == 1
+    )
+
+
+def test_grouped_plot_infers_compartments(tmp_path):
+    output = {
+        f"{compartment}_{patch_idx}_{group_idx}": [value, value]
+        for patch_idx in range(2)
+        for group_idx in range(2)
+        for compartment, value in (("S", 90.0), ("I", 10.0))
+    }
+
+    plot_patch_subplots(
+        [0, 1],
+        output,
+        ["A", "B"],
+        tmp_path,
+        "groups",
+        groups=["low", "high"],
+    )
+
+    assert (tmp_path / "patch_timeseries_groups_ode.png").is_file()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add one optional modeller-defined group axis within each spatial patch
- accept a shared focal-by-contributor interaction matrix with explicit units and diagnostic validation
- compose spatial and group mixing for both ODE and discrete solvers while preserving existing ungrouped behavior
- document the contracts, units, limits, outputs, and one complete worked example

## Model contract
For focal patch `i` and group `a`, infectious pressure is `sum(j,b) W[i,j] M[a,b] I[j,b] / N[j,b]`. A zero-population contributor has zero prevalence. PatchSim does not normalize, symmetrize, or demographically adjust the supplied interaction matrix.

The initial scope is one group axis and one shared static interaction matrix. Patch-specific interactions, group-specific mobility, proxy generators, multiple axes, and group-specific parameters remain deferred.

## Validation
- `uv run --frozen --extra lint ruff check .`
- `uv run --frozen --extra lint ruff format --check .`
- `uv run --frozen --extra test pytest -q` (`132 passed`)
- `uv run --frozen --extra docs sphinx-build -b html docs /tmp/patchsim-docs-groups-final -W`
- exact worked example validated and run; initial pressures were `0.04` and `0.005`, giving infection flows `0.2388` and `0.12`
- rendered group guide checked at desktop and mobile widths with no horizontal overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional group stratification for simulations, including per-patch populations and interaction weights.
  * Added grouped validation and run summaries with group metadata and interaction diagnostics.
  * Added grouped outputs and plots with compartment/group labels.

* **Documentation**
  * Added comprehensive group stratification guidance, examples, configuration details, validation rules, equations, outputs, and limitations.
  * Updated CLI, results, and feature documentation to describe grouped simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->