### PR TITLE
feat: add reproducible Sobol sensitivity analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version-file: .python-version
 
       - name: Sync dependencies (including dev)
-        run: uv sync --extra dev --extra geo --frozen
+        run: uv sync --extra analysis --extra dev --extra geo --frozen
 
       - name: Ruff lint
         run: uv run --no-sync --frozen ruff check .

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 **PatchSim** is a modular metapopulation simulation framework for multi-disease epidemiological modelling.
 
+[Documentation](https://patchsim.readthedocs.io/) |
+[GitHub repository](https://github.com/dsih-artpark/patchsim)
+
 ---
 
 ## Vision
@@ -48,11 +51,12 @@ PatchSim aims to support a range of modelling features commonly used in metapopu
   - SIR, SEIR, SIRS and extensions
   - Supports both discrete timestep and ODE-based solvers
 - 🛠️ **Scenario and Parameter Management**:
-  - Batch simulations for scenario comparison
-  - Sensitivity analysis and parameter sweeps
+  - First-order and total-order Sobol sensitivity analysis for bounded global
+    parameters
+  - Compact samples, responses, indices, and provenance artifacts
 - 🧵 **Reproducibility**:
-  - Random seed control and metadata logging
-  - Version-tracked configurations
+  - Seeded sensitivity sampling and confidence intervals
+  - Input hashes and method versions in sensitivity manifests
 - 📦 **Modularity**:
   - Built-in ODE and discrete solvers consume the same validated spatial network
     format
@@ -65,6 +69,12 @@ Install from PyPI:
 
 ```bash
 pip install patchsim
+```
+
+Sensitivity analysis uses an optional dependency:
+
+```bash
+pip install "patchsim[analysis]"
 ```
 
 Install from source using [uv](https://github.com/astral-sh/uv):
@@ -119,6 +129,9 @@ uv run patchsim run -c my-project/config.yaml
 # Run and emit machine-readable JSON output
 uv run patchsim run -c my-project/config.yaml --json
 
+# Run or reuse a configured Sobol sensitivity study
+uv run patchsim sensitivity -c my-project/config.yaml
+
 # List built-in model references and YAML templates
 uv run patchsim list-models
 
@@ -132,44 +145,19 @@ uv run patchsim list-models --json
 import patchsim
 
 config = patchsim.load_config("config.yaml")
-net, y0, patches, n = patchsim.setup_simulation(config)
-patchsim.run_simulation(config, "my-model", net, y0, patches, n)
+frame = patchsim.simulate(config, parameter_overrides={"beta": 0.08})
 ```
 
-The simulation outputs are saved in the following structure:
-```
-output/
-├── logs/
-│   └── cli_YYYYMMDD_HHMMSS.log  # Timestamped log files
-└── sample-sir-ode/              # Model-specific output directory
-    ├── plots/
-    │   └── patch_timeseries_sample-sir-ode_ode.png
-    └── runs/
-        └── all_patches_sample-sir-ode_ode.csv
-```
+`simulate` returns the configured time series without writing files or mutating
+the loaded config. It is the integration point for external fitting code.
 
 ### Configuration
 
-Simulations are configured using YAML files. The configuration file specifies:
-- Model parameters (e.g., transmission rates)
-- Input files (patch populations, seed data, network)
-- Simulation settings (time horizon, output directory)
-
-Example configuration:
-```yaml
-# Model parameters
-Beta: 0.3
-Gamma: 0.1
-
-# Input files
-PatchFile: data/patch/sample-sir-ode-patch-population.csv
-SeedFile: data/seeds/sample-sir-ode-patchA-2.csv
-NetworkFile: data/networks/sample-network-static.csv
-
-# Simulation settings
-OutputDir: output/sample-sir-ode
-TMax: 50
-```
+YAML configuration defines model parameters, transition expressions, input
+files, solver settings, and output location. See the
+[configuration reference](https://patchsim.readthedocs.io/en/latest/configuration.html)
+and the
+[worked simulation and sensitivity workflow](https://patchsim.readthedocs.io/en/latest/simulation-workflow.html).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,21 +12,32 @@ CLI
   -> setup_simulation
   -> NetworkModel + initial state
   -> NetworkModel.simulate_ode | NetworkModel.simulate_discrete
-  -> CSV + PNG + log
+  -> run: CSV + PNG + log
+  -> sensitivity: samples + responses + indices + manifest
 ```
 
 ## Components
 
 ### `patchsim.cli`
 
-Defines `init`, `validate`, `run`, and `list-models`. It owns argument parsing,
-human or JSON command output, and process exit behavior.
+Defines `init`, `validate`, `run`, `sensitivity`, `list-models`, and contact
+generation. It owns argument parsing, human or JSON command output, and process
+exit behavior.
 
 ### `patchsim.core.simulation`
 
 Owns the configuration schema and built-in template data. It resolves
 config-relative paths, validates CSV inputs, constructs the dense network matrix,
 creates the compartment/network model, and writes run artifacts.
+
+The public `patchsim.simulate` evaluator uses the same prepared solver path and
+returns a time-series frame without writing files.
+
+### `patchsim.sensitivity`
+
+Validates the bounded Sobol contract, samples through optional SALib, reduces
+model trajectories to scalar metrics, and atomically publishes study artifacts.
+An existing study is reused only after request and artifact hashes match.
 
 ### `patchsim.core.model`
 
@@ -58,8 +69,8 @@ and discrete paths share the same derivative function.
 - `NetworkFile` owns the day-zero dense matrix entries.
 - `OutputDir` owns user-facing run artifacts.
 
-There is no hidden project state directory and no persistent cache in the current
-implementation.
+There is no hidden project state directory. Sensitivity reuse is limited to the
+explicit named study directory under `OutputDir`.
 
 ## Current extension boundary
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,6 +31,7 @@ The CLI uses these conventions:
 | `init` | Create a project from a built-in template |
 | `validate` | Load and validate a configuration and its input files |
 | `run` | Run the configured solver and write artifacts |
+| `sensitivity` | Run or reuse a configured Sobol study |
 | `list-models` | List built-in project templates |
 | `generate-contacts` | Generate a validated spatial network CSV |
 
@@ -129,6 +130,25 @@ The CSV and PNG names are deterministic per solver. A rerun with the same
 different `TimeStep`. Use one output directory per retained scenario or run.
 Logs remain separate because their names include a timestamp.
 :::
+
+## `sensitivity`
+
+```bash
+patchsim sensitivity -c CONFIG [--json]
+```
+
+The command validates the simulation and `Sensitivity` block, reports the
+planned evaluation count to standard error, and computes first-order and
+total-order Sobol indices. It requires the `analysis` optional dependency.
+
+The result summary contains `reused`, planned and completed evaluation counts,
+elapsed seconds, and absolute paths to `samples.csv`, `responses.csv`,
+`indices.csv`, and `manifest.json`. JSON mode keeps standard output valid JSON.
+
+An existing named study is reused only when its request fingerprint and table
+hashes match. A reused invocation reports zero completed evaluations. Changed
+or incomplete studies fail rather than being overwritten. See the
+{ref}`worked workflow <sensitivity-study>`.
 
 ## `list-models`
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+html_context = {"default_mode": "auto"}
 html_theme_options = {
     "icon_links": [
         {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ a network. Run `patchsim validate -c CONFIG` before `patchsim run`.
 | `compartments` | No | Ordered compartment names; inferred from `SeedFile` if absent |
 | `Parameters` | No | Global names available to transition expressions |
 | `PatchParameters` | No | Per-patch parameter overrides |
+| `Sensitivity` | For `sensitivity` | Sobol study name, seed, bounds, and scalar metrics |
 
 `Compartments` with an uppercase `C` is also accepted for compatibility.
 `compartments` is the documented spelling.
@@ -243,6 +244,22 @@ PatchParameters:
 
 Patch names are validated, and each override is merged with the global parameter
 mapping during setup. Both built-in solvers use these merged parameters.
+
+## Sensitivity block
+
+`Sensitivity` is optional for normal runs and required by `patchsim
+sensitivity`. `patchsim validate` checks it when present. Version 1 supports
+first-order and total-order Sobol indices for independent uniform bounds on
+global parameters. It does not sample patch-specific, group-specific, integer,
+categorical, correlated, network, or interaction-matrix inputs.
+
+`BaseSamples` must be a power of two of at least 2, and `Seed` is required. `Name`
+must be a single safe path component. Metrics sum exact output columns and use
+either `max` or `final`; names may not collide with sampled parameter columns or
+`sample_id`.
+
+See {ref}`Simulation workflow <sensitivity-study>` for the complete
+configuration and interpretation guidance.
 
 ## Accepted compatibility fields
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,12 @@ cd patchsim
 uv sync --extra dev --frozen
 ```
 
+Add `--extra analysis` when running sensitivity studies or their tests:
+
+```bash
+uv sync --extra analysis --extra dev --frozen
+```
+
 The rest of this page uses `patchsim`. Replace it with `uv run patchsim` when
 working from the source checkout.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ version, and validate every configuration before running it.
 - [Mathematical model](mathematical-model.md): transition and network equations.
 - [Group stratification](group-stratification.md): custom groups and interaction matrices.
 - [Contact generation](contact-generation.md): spatial kernels, units, and validation.
+- [Simulation workflow](simulation-workflow.md): solver steps and a complete Sobol example.
 - [Results](results.md): output paths, column naming, and rerun behavior.
 
 ## Documentation conventions

--- a/docs/results.md
+++ b/docs/results.md
@@ -22,6 +22,27 @@ The `OutputDir` path is resolved relative to the configuration file.
 PatchSim does not create or require a `.patchsim` directory. All current run
 artifacts are user-facing files.
 
+Sensitivity studies add one named directory:
+
+```text
+OutputDir/
+  sensitivity/
+    NAME/
+      samples.csv
+      responses.csv
+      indices.csv
+      manifest.json
+```
+
+`samples.csv` contains the SALib design, `responses.csv` contains one scalar
+per configured metric and sample, and `indices.csv` contains `S1`, `ST`, and
+their confidence intervals. `manifest.json` records method settings, versions,
+the normalized config, source/input hashes, and hashes of the three tables.
+The manifest does not copy its inputs.
+
+A matching named study is reused after hash verification. A changed or partial
+study is not overwritten.
+
 ## Retention and overwrite behavior
 
 The CSV and PNG filenames are deterministic for each solver. Running the same

--- a/docs/simulation-workflow.md
+++ b/docs/simulation-workflow.md
@@ -53,6 +53,91 @@ The log and JSON run summary record the selected solver and `TimeStep`.
 The CSV and PNG are replaced by a rerun with the same `ModelName`, `OutputDir`,
 and solver. See [Results](results.md) for retention conventions.
 
+(sensitivity-study)=
+
+## 6. Optional sensitivity study
+
+Install the analysis dependency:
+
+```bash
+python -m pip install "patchsim[analysis]"
+```
+
+Add one `Sensitivity` block to the same simulation config:
+
+```yaml
+Sensitivity:
+  Name: beta-gamma
+  Method: sobol
+  BaseSamples: 256
+  Seed: 20260728
+  Parameters:
+    beta: [0.04, 0.12]
+    gamma: [0.05, 0.20]
+  Metrics:
+    peak_infectious:
+      Columns: [I_0, I_1]
+      Reduce: max
+    final_removed:
+      Columns: [R_0, R_1]
+      Reduce: final
+```
+
+The bounds define independent uniform input distributions. Both names must be
+global `Parameters`; a name also present in `PatchParameters` is rejected.
+Metric columns must exactly match the time-series columns for the configured
+patch and group structure. PatchSim sums each metric's columns at every
+reporting point, then takes `max` or `final`. A maximum is therefore a maximum
+on the reporting grid, not a continuous-time optimum.
+
+Validate before committing the compute budget:
+
+```bash
+patchsim validate -c config.yaml
+```
+
+With two parameters and `BaseSamples: 256`, the first-order/total-order Sobol
+design requires:
+
+```text
+256 * (2 + 2) = 1024 model evaluations
+```
+
+Run the study:
+
+```bash
+patchsim sensitivity -c config.yaml
+```
+
+PatchSim writes:
+
+```text
+OutputDir/
+  sensitivity/
+    beta-gamma/
+      samples.csv
+      responses.csv
+      indices.csv
+      manifest.json
+```
+
+`indices.csv` contains `S1`, `ST`, and their seeded bootstrap confidence
+interval widths for every metric/parameter pair. `S1` measures the parameter's
+first-order contribution; `ST` includes all interactions involving that
+parameter. A material `ST - S1` can indicate aggregate interactions, but this
+version does not attribute interactions to parameter pairs.
+
+Repeat the study with `BaseSamples` doubled and a different `Name`. Compare
+changes in the indices and confidence intervals; a power-of-two sample count
+does not certify convergence. Sobol analysis also assumes the configured
+independent bounds are scientifically meaningful. Correlated or jointly
+constrained parameters need another method.
+
+Reusing the same `Name` with the exact same config, inputs, method, and relevant
+versions verifies the saved hashes and returns the existing artifacts without
+new solves. PatchSim refuses an incomplete, modified, or different study at
+that path. It does not create a hidden cache or overwrite a study.
+
 ## Reproducible run checklist
 
 Retain:
@@ -65,3 +150,8 @@ Retain:
 
 The current run log records Python and platform details but does not capture the
 PatchSim package version or immutable copies of the inputs.
+
+For sensitivity studies, `manifest.json` records the normalized configuration,
+source and input hashes, method settings, versions, and artifact hashes. It
+detects changed files but does not copy them, so retain the original YAML and
+CSV inputs.

--- a/docs/simulation-workflow.md
+++ b/docs/simulation-workflow.md
@@ -122,10 +122,11 @@ OutputDir/
 ```
 
 `indices.csv` contains `S1`, `ST`, and their seeded bootstrap confidence
-interval widths for every metric/parameter pair. `S1` measures the parameter's
-first-order contribution; `ST` includes all interactions involving that
-parameter. A material `ST - S1` can indicate aggregate interactions, but this
-version does not attribute interactions to parameter pairs.
+interval half-widths for every metric/parameter pair. The intervals are the
+estimate plus or minus the corresponding `_conf` value. `S1` measures the
+parameter's first-order contribution; `ST` includes all interactions involving
+that parameter. A material `ST - S1` can indicate aggregate interactions, but
+this version does not attribute interactions to parameter pairs.
 
 Repeat the study with `BaseSamples` doubled and a different `Name`. Compare
 changes in the indices and confidence intervals; a power-of-two sample count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "pyyaml>=6.0",
     "tqdm>=4.66",
     "networkx>=3.3",
-    "SALib>=1.5",
     "rich>=14.3.3",
 ]
 
@@ -48,6 +47,10 @@ Documentation = "https://patchsim.readthedocs.io/"
 geo = [
     "geopandas>=1.1",
     "pyproj>=3.5",
+]
+
+analysis = [
+    "SALib>=1.5.2",
 ]
 
 test = [

--- a/src/patchsim/__init__.py
+++ b/src/patchsim/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from patchsim.core.model import CompartmentalModel, NetworkModel
-from patchsim.core.simulation import load_config, run_simulation, setup_simulation
+from patchsim.core.simulation import load_config, run_simulation, setup_simulation, simulate
 from patchsim.utils.viz import plot_patch_subplots
 
 try:
@@ -21,4 +21,5 @@ __all__ = [
     "plot_patch_subplots",
     "run_simulation",
     "setup_simulation",
+    "simulate",
 ]

--- a/src/patchsim/cli.py
+++ b/src/patchsim/cli.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import shutil
+import sys
 import textwrap
 from importlib import resources
 from pathlib import Path
@@ -19,6 +20,7 @@ from patchsim.core.simulation import (
     run_simulation,
     setup_simulation,
 )
+from patchsim.sensitivity import get_sensitivity_plan, run_sensitivity
 from patchsim.utils.geo import generate_contacts
 
 
@@ -62,8 +64,11 @@ def _cmd_validate(config_path: str, *, json_output: bool = False, schema: bool =
 
     config = load_config(config_path)
     net, _y0, patches, num_patches = setup_simulation(config)
+    sensitivity = get_sensitivity_plan(config, list(net.all_compartments), required=False)
     if not json_output:
         print(f"Configuration is valid: {config_path}")
+        if sensitivity:
+            print(f"Planned sensitivity evaluations: {sensitivity.evaluation_count}")
         if net.groups:
             diagnostics = net.interaction_diagnostics
             print(
@@ -89,8 +94,28 @@ def _cmd_validate(config_path: str, *, json_output: bool = False, schema: bool =
                     "interaction": net.interaction_diagnostics,
                 }
             )
+        if sensitivity:
+            result["sensitivity"] = {
+                "name": sensitivity.name,
+                "method": "sobol",
+                "num_parameters": len(sensitivity.parameters),
+                "evaluation_count": sensitivity.evaluation_count,
+            }
         return result
     return None
+
+
+def _cmd_sensitivity(config_path: str, *, json_output: bool = False) -> dict[str, Any]:
+    summary = run_sensitivity(config_path, progress=lambda message: print(message, file=sys.stderr))
+    result = {"ok": True, "config": config_path, **summary}
+    if not json_output:
+        action = "Reused" if summary["reused"] else "Completed"
+        print(f"{action} sensitivity study: {summary['output_dir']}")
+        print(f"Samples: {summary['samples_path']}")
+        print(f"Responses: {summary['responses_path']}")
+        print(f"Indices: {summary['indices_path']}")
+        print(f"Manifest: {summary['manifest_path']}")
+    return result
 
 
 def _copy_template_tree(template_node, target_path: Path) -> None:
@@ -225,6 +250,7 @@ Examples:
     uv run patchsim init my-project --template seir
     uv run patchsim run -c my-project/config.yaml
     uv run patchsim validate -c my-project/config.yaml
+    uv run patchsim sensitivity -c my-project/config.yaml
     uv run patchsim list-models
     uv run patchsim generate-contacts centroids.csv contacts.csv --id-column id \
         --kernel distance --decay 2 --min-distance-km 0.001 --normalize row --self-share 0.9
@@ -248,6 +274,10 @@ Examples:
     run_p = subparsers.add_parser("run", help="Run a simulation")
     run_p.add_argument("-c", "--config", required=True, help="Path to simulation config YAML")
     run_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON summary")
+
+    sensitivity_p = subparsers.add_parser("sensitivity", help="Run or reuse a Sobol sensitivity study")
+    sensitivity_p.add_argument("-c", "--config", required=True, help="Path to simulation config YAML")
+    sensitivity_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON summary")
 
     validate_p = subparsers.add_parser("validate", help="Validate config and inputs")
     validate_p.add_argument("-c", "--config", help="Path to simulation config YAML")
@@ -290,6 +320,10 @@ Examples:
             _cmd_init(args.name, force=args.force, template=args.template)
         elif args.command == "run":
             result = _cmd_run(args.config, json_output=args.json)
+            if args.json:
+                _emit_json(result)
+        elif args.command == "sensitivity":
+            result = _cmd_sensitivity(args.config, json_output=args.json)
             if args.json:
                 _emit_json(result)
         elif args.command == "validate":

--- a/src/patchsim/core/simulation.py
+++ b/src/patchsim/core/simulation.py
@@ -113,7 +113,11 @@ def get_config_schema() -> dict[str, Any]:
                         "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
                     },
                     "Method": {"const": "sobol"},
-                    "BaseSamples": {"type": "integer", "minimum": 2},
+                    "BaseSamples": {
+                        "type": "integer",
+                        "minimum": 2,
+                        "description": "Power of two; minimum 2.",
+                    },
                     "Seed": {"type": "integer", "minimum": 0},
                     "Parameters": {
                         "type": "object",

--- a/src/patchsim/core/simulation.py
+++ b/src/patchsim/core/simulation.py
@@ -6,6 +6,7 @@ ODE and discrete simulation logic is implemented in core/model.py.
 import hashlib
 import os
 import re
+from copy import deepcopy
 from numbers import Real
 from pathlib import Path
 from typing import Any
@@ -102,6 +103,48 @@ def get_config_schema() -> dict[str, Any]:
                     },
                     "additionalProperties": True,
                 },
+            },
+            "Sensitivity": {
+                "type": "object",
+                "required": ["Name", "Method", "BaseSamples", "Seed", "Parameters", "Metrics"],
+                "properties": {
+                    "Name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+                    },
+                    "Method": {"const": "sobol"},
+                    "BaseSamples": {"type": "integer", "minimum": 2},
+                    "Seed": {"type": "integer", "minimum": 0},
+                    "Parameters": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": {
+                            "type": "array",
+                            "prefixItems": [{"type": "number"}, {"type": "number"}],
+                            "minItems": 2,
+                            "maxItems": 2,
+                        },
+                    },
+                    "Metrics": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": {
+                            "type": "object",
+                            "required": ["Columns", "Reduce"],
+                            "properties": {
+                                "Columns": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "minItems": 1,
+                                    "uniqueItems": True,
+                                },
+                                "Reduce": {"type": "string", "enum": ["max", "final"]},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "additionalProperties": False,
             },
             "Transitions": {
                 "type": "object",
@@ -626,6 +669,63 @@ def setup_simulation(config: dict[str, Any]) -> tuple[NetworkModel, dict[str, fl
     return net, y0, patches, num_patches
 
 
+def _simulate_prepared(
+    config: dict[str, Any],
+    net: NetworkModel,
+    y0: dict[str, float],
+) -> pd.DataFrame:
+    """Evaluate a prepared model on its configured reporting grid."""
+    solver, t_max, time_step = get_run_settings(config)
+    t_range = np.arange(t_max, dtype=float) * time_step
+    if solver == "ode":
+        _times, results = net.simulate_ode(y0, t_range)
+    else:
+        results = net.simulate_discrete(y0, t_range)
+
+    frame = pd.DataFrame(results)
+    frame.insert(0, "time", t_range)
+    return frame
+
+
+def simulate(
+    config: dict[str, Any] | str | Path,
+    *,
+    parameter_overrides: dict[str, Real] | None = None,
+) -> pd.DataFrame:
+    """Run a simulation in memory without mutating the config or writing files.
+
+    A mapping must already contain resolved input paths, as returned by
+    :func:`load_config`. Passing a path loads and resolves the configuration.
+    """
+    prepared = load_config(str(config)) if isinstance(config, (str, Path)) else deepcopy(config)
+    if not isinstance(prepared, dict):
+        raise TypeError("config must be a loaded configuration mapping or a path")
+
+    overrides = parameter_overrides or {}
+    if not isinstance(overrides, dict):
+        raise TypeError("parameter_overrides must be a mapping")
+    global_parameters = prepared.get("Parameters", {})
+    if not isinstance(global_parameters, dict):
+        raise ValueError("'Parameters' must be a mapping")
+
+    patch_parameter_names: set[str] = set()
+    for entry in prepared.get("PatchParameters", []):
+        if isinstance(entry, dict) and isinstance(entry.get("parameters", {}), dict):
+            patch_parameter_names.update(entry.get("parameters", {}))
+
+    for name, value in overrides.items():
+        if name not in global_parameters:
+            raise ValueError(f"Unknown global parameter override: {name!r}")
+        if name in patch_parameter_names:
+            raise ValueError(f"Cannot globally override {name!r}; it is also set in PatchParameters")
+        if isinstance(value, bool) or not isinstance(value, Real) or not np.isfinite(value):
+            raise ValueError(f"Parameter override {name!r} must be a finite real number")
+
+    prepared["Parameters"] = {**global_parameters, **overrides}
+    net, y0, _patches, _num_patches = setup_simulation(prepared)
+    return _simulate_prepared(prepared, net, y0)
+
+
 def run_simulation(
     config: dict[str, Any], model_name: str, net: NetworkModel, y0: dict[str, float], patches: list, num_patches: int
 ) -> dict[str, Any]:
@@ -649,19 +749,9 @@ def run_simulation(
     # Set up logger
     logger = setup_logger(model_name, config, num_patches, patches, net.base_model)
 
-    t_range = np.arange(t_max, dtype=float) * time_step
-
-    # Run simulation
-    if solver == "ode":
-        _times, results = net.simulate_ode(y0, t_range)
-    else:
-        results = net.simulate_discrete(y0, t_range)
-
-    # Save results
-    out_df = pd.DataFrame(results)
-    out_df["time"] = t_range
-    cols = ["time"] + [c for c in out_df.columns if c != "time"]
-    out_df = out_df[cols]
+    out_df = _simulate_prepared(config, net, y0)
+    t_range = out_df["time"].to_numpy()
+    results = {column: out_df[column].to_numpy() for column in out_df.columns if column != "time"}
 
     csv_path = os.path.join(runs_dir, f"all_patches_{model_name}_{solver}.csv")
     out_df.to_csv(csv_path, index=False)

--- a/src/patchsim/sensitivity.py
+++ b/src/patchsim/sensitivity.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import tempfile
 import time
+from copy import deepcopy
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from numbers import Real
@@ -279,6 +280,7 @@ def run_sensitivity(
     started = time.monotonic()
     source_path = Path(config_path).expanduser().resolve()
     config = load_config(str(source_path))
+    request_config = deepcopy(config)
     net, y0, _patches, _num_patches = setup_simulation(config)
     plan = get_sensitivity_plan(config, list(net.all_compartments))
     assert plan is not None
@@ -287,7 +289,7 @@ def run_sensitivity(
 
     sobol_sample, sobol_analyze, salib_version = _load_salib()
     source_config_sha256 = _sha256(source_path)
-    request = _request_record(config, salib_version, source_config_sha256)
+    request = _request_record(request_config, salib_version, source_config_sha256)
     fingerprint = hashlib.sha256(_canonical_bytes(request)).hexdigest()
     output_root = Path(config["OutputDir"]).resolve()
     sensitivity_root = output_root / "sensitivity"

--- a/src/patchsim/sensitivity.py
+++ b/src/patchsim/sensitivity.py
@@ -1,0 +1,418 @@
+"""Sobol sensitivity studies for PatchSim configurations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from numbers import Real
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+from patchsim.core.simulation import _simulate_prepared, load_config, setup_simulation
+
+_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+_INPUT_FIELDS = ("PatchFile", "SeedFile", "NetworkFile", "GroupFile", "InteractionFile")
+_ARTIFACT_NAMES = ("samples.csv", "responses.csv", "indices.csv")
+_MIN_SALIB_VERSION = (1, 5, 2)
+_NUM_RESAMPLES = 100
+_CONF_LEVEL = 0.95
+
+
+@dataclass(frozen=True)
+class Metric:
+    name: str
+    columns: tuple[str, ...]
+    reducer: str
+
+
+@dataclass(frozen=True)
+class SensitivityPlan:
+    name: str
+    base_samples: int
+    seed: int
+    parameters: tuple[tuple[str, float, float], ...]
+    metrics: tuple[Metric, ...]
+
+    @property
+    def evaluation_count(self) -> int:
+        return self.base_samples * (len(self.parameters) + 2)
+
+
+def _parse_version(value: str) -> tuple[int, int, int]:
+    match = re.match(r"(\d+)\.(\d+)\.(\d+)", value)
+    return tuple(map(int, match.groups())) if match else (0, 0, 0)
+
+
+def _load_salib():
+    try:
+        salib_version = version("SALib")
+        from SALib.analyze import sobol as sobol_analyze
+        from SALib.sample import sobol as sobol_sample
+    except (ImportError, PackageNotFoundError) as exc:
+        raise RuntimeError(
+            "Sensitivity analysis requires SALib 1.5.2 or newer. "
+            'Install it with `python -m pip install "patchsim[analysis]"`.'
+        ) from exc
+    if _parse_version(salib_version) < _MIN_SALIB_VERSION:
+        raise RuntimeError(
+            f"Sensitivity analysis requires SALib 1.5.2 or newer; found {salib_version}. "
+            'Upgrade with `python -m pip install --upgrade "patchsim[analysis]"`.'
+        )
+    return sobol_sample, sobol_analyze, salib_version
+
+
+def _patch_parameter_names(config: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for entry in config.get("PatchParameters", []):
+        if isinstance(entry, dict) and isinstance(entry.get("parameters", {}), dict):
+            names.update(entry.get("parameters", {}))
+    return names
+
+
+def get_sensitivity_plan(
+    config: dict[str, Any],
+    output_columns: list[str],
+    *,
+    required: bool = True,
+) -> SensitivityPlan | None:
+    """Validate the optional Sensitivity block against a prepared model."""
+    raw = config.get("Sensitivity")
+    if raw is None:
+        if required:
+            raise ValueError("The configuration has no 'Sensitivity' block")
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("'Sensitivity' must be a mapping")
+
+    name = raw.get("Name")
+    if not isinstance(name, str) or not _NAME_PATTERN.fullmatch(name) or name in {".", ".."}:
+        raise ValueError("'Sensitivity.Name' must be one safe path component using letters, numbers, '.', '_', or '-'")
+    if raw.get("Method") != "sobol":
+        raise ValueError("'Sensitivity.Method' must be 'sobol'")
+
+    base_samples = raw.get("BaseSamples")
+    if (
+        isinstance(base_samples, bool)
+        or not isinstance(base_samples, int)
+        or base_samples < 2
+        or base_samples & (base_samples - 1)
+    ):
+        raise ValueError("'Sensitivity.BaseSamples' must be a power of two of at least 2")
+    seed = raw.get("Seed")
+    if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+        raise ValueError("'Sensitivity.Seed' must be a non-negative integer")
+
+    global_parameters = config.get("Parameters", {})
+    if not isinstance(global_parameters, dict):
+        raise ValueError("'Parameters' must be a mapping")
+    patch_parameters = _patch_parameter_names(config)
+    raw_parameters = raw.get("Parameters")
+    if not isinstance(raw_parameters, dict) or not raw_parameters:
+        raise ValueError("'Sensitivity.Parameters' must contain at least one parameter")
+
+    parameters = []
+    for parameter_name, bounds in raw_parameters.items():
+        if not isinstance(parameter_name, str) or not parameter_name or parameter_name == "sample_id":
+            raise ValueError("Sensitivity parameter names must be non-empty and may not be 'sample_id'")
+        if parameter_name not in global_parameters:
+            raise ValueError(f"Unknown global sensitivity parameter: {parameter_name!r}")
+        if parameter_name in patch_parameters:
+            raise ValueError(f"Cannot sample {parameter_name!r}; it is also set in PatchParameters")
+        if not isinstance(bounds, (list, tuple)) or len(bounds) != 2:
+            raise ValueError(f"Bounds for {parameter_name!r} must be [lower, upper]")
+        lower, upper = bounds
+        if any(isinstance(value, bool) or not isinstance(value, Real) for value in bounds):
+            raise ValueError(f"Bounds for {parameter_name!r} must be finite real numbers")
+        lower, upper = float(lower), float(upper)
+        if not np.isfinite(lower) or not np.isfinite(upper) or lower >= upper:
+            raise ValueError(f"Bounds for {parameter_name!r} must satisfy finite lower < upper")
+        parameters.append((parameter_name, lower, upper))
+
+    raw_metrics = raw.get("Metrics")
+    if not isinstance(raw_metrics, dict) or not raw_metrics:
+        raise ValueError("'Sensitivity.Metrics' must contain at least one metric")
+    parameter_names = {name for name, _lower, _upper in parameters}
+    available_columns = set(output_columns)
+    metrics = []
+    for metric_name, metric_config in raw_metrics.items():
+        if (
+            not isinstance(metric_name, str)
+            or not metric_name
+            or metric_name == "sample_id"
+            or metric_name in parameter_names
+        ):
+            raise ValueError(
+                "Sensitivity metric names must be non-empty and distinct from parameter columns and 'sample_id'"
+            )
+        if not isinstance(metric_config, dict):
+            raise ValueError(f"Metric {metric_name!r} must be a mapping")
+        columns = metric_config.get("Columns")
+        if (
+            not isinstance(columns, list)
+            or not columns
+            or not all(isinstance(column, str) for column in columns)
+            or len(columns) != len(set(columns))
+        ):
+            raise ValueError(f"Metric {metric_name!r} Columns must be a non-empty list of unique names")
+        unknown = sorted(set(columns) - available_columns)
+        if unknown:
+            raise ValueError(f"Metric {metric_name!r} references unknown output columns: {unknown}")
+        reducer = metric_config.get("Reduce")
+        if reducer not in {"max", "final"}:
+            raise ValueError(f"Metric {metric_name!r} Reduce must be 'max' or 'final'")
+        metrics.append(Metric(metric_name, tuple(columns), reducer))
+
+    return SensitivityPlan(name, base_samples, seed, tuple(parameters), tuple(metrics))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False, default=str).encode()
+
+
+def _versions(salib_version: str) -> dict[str, str]:
+    result = {"SALib": salib_version}
+    for package in ("patchsim", "numpy", "pandas", "scipy"):
+        try:
+            result[package] = version(package)
+        except PackageNotFoundError:
+            result[package] = "unknown"
+    return result
+
+
+def _request_record(
+    config: dict[str, Any],
+    salib_version: str,
+    source_config_sha256: str,
+) -> dict[str, Any]:
+    inputs = {
+        field: {"path": str(config[field]), "sha256": _sha256(Path(config[field]))}
+        for field in _INPUT_FIELDS
+        if config.get(field)
+    }
+    method = {
+        "name": "sobol",
+        "calc_second_order": False,
+        "scramble": True,
+        "skip_values": 0,
+        "num_resamples": _NUM_RESAMPLES,
+        "conf_level": _CONF_LEVEL,
+    }
+    return {
+        "normalized_config": json.loads(json.dumps(config, default=str)),
+        "source_config_sha256": source_config_sha256,
+        "inputs": inputs,
+        "method": method,
+        "versions": _versions(salib_version),
+    }
+
+
+def _artifact_paths(target: Path) -> dict[str, str]:
+    return {
+        "output_dir": str(target),
+        "samples_path": str(target / "samples.csv"),
+        "responses_path": str(target / "responses.csv"),
+        "indices_path": str(target / "indices.csv"),
+        "manifest_path": str(target / "manifest.json"),
+    }
+
+
+def _reuse_existing(
+    target: Path,
+    fingerprint: str,
+    evaluation_count: int,
+) -> dict[str, Any]:
+    manifest_path = target / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FileExistsError(f"Existing sensitivity target is incomplete: {target}") from exc
+    request = manifest.get("request")
+    if (
+        manifest.get("schema_version") != 1
+        or not isinstance(request, dict)
+        or hashlib.sha256(_canonical_bytes(request)).hexdigest() != fingerprint
+        or manifest.get("study_fingerprint") != fingerprint
+        or manifest.get("evaluation_count") != evaluation_count
+        or manifest.get("source_config", {}).get("sha256") != request.get("source_config_sha256")
+    ):
+        raise FileExistsError(f"Existing sensitivity target was produced by a different study: {target}")
+
+    recorded = manifest.get("artifacts", {})
+    for filename in _ARTIFACT_NAMES:
+        path = target / filename
+        expected = recorded.get(filename, {}).get("sha256")
+        if not path.is_file() or expected != _sha256(path):
+            raise FileExistsError(f"Existing sensitivity artifact is missing or modified: {path}")
+
+    return {
+        **_artifact_paths(target),
+        "reused": True,
+        "planned_evaluations": evaluation_count,
+        "completed_evaluations": 0,
+    }
+
+
+def _metric_value(frame: pd.DataFrame, metric: Metric) -> float:
+    series = frame.loc[:, metric.columns].sum(axis=1, skipna=False)
+    return float(series.max() if metric.reducer == "max" else series.iloc[-1])
+
+
+def run_sensitivity(
+    config_path: str | Path,
+    *,
+    progress: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Run or reuse one configured Sobol sensitivity study."""
+    started = time.monotonic()
+    source_path = Path(config_path).expanduser().resolve()
+    config = load_config(str(source_path))
+    net, y0, _patches, _num_patches = setup_simulation(config)
+    plan = get_sensitivity_plan(config, list(net.all_compartments))
+    assert plan is not None
+    if progress:
+        progress(f"Planned model evaluations: {plan.evaluation_count}")
+
+    sobol_sample, sobol_analyze, salib_version = _load_salib()
+    source_config_sha256 = _sha256(source_path)
+    request = _request_record(config, salib_version, source_config_sha256)
+    fingerprint = hashlib.sha256(_canonical_bytes(request)).hexdigest()
+    output_root = Path(config["OutputDir"]).resolve()
+    sensitivity_root = output_root / "sensitivity"
+    resolved_sensitivity_root = sensitivity_root.resolve()
+    if not resolved_sensitivity_root.is_relative_to(output_root):
+        raise ValueError(f"Sensitivity output path escapes OutputDir: {sensitivity_root}")
+    target = sensitivity_root / plan.name
+    if target.is_symlink() or not target.resolve().is_relative_to(resolved_sensitivity_root):
+        raise ValueError(f"Sensitivity output path escapes its study directory: {target}")
+    if target.exists():
+        summary = _reuse_existing(target, fingerprint, plan.evaluation_count)
+        summary["elapsed_seconds"] = time.monotonic() - started
+        return summary
+
+    names = [name for name, _lower, _upper in plan.parameters]
+    problem = {
+        "num_vars": len(names),
+        "names": names,
+        "bounds": [[lower, upper] for _name, lower, upper in plan.parameters],
+    }
+    samples = sobol_sample.sample(
+        problem,
+        plan.base_samples,
+        calc_second_order=False,
+        scramble=True,
+        skip_values=0,
+        seed=plan.seed,
+    )
+    responses = {metric.name: [] for metric in plan.metrics}
+
+    for sample_id, sample in enumerate(samples):
+        values = dict(zip(names, map(float, sample), strict=True))
+        net.base_model.parameters.update(values)
+        for patch_parameters in net.patch_parameters.values():
+            patch_parameters.update(values)
+        try:
+            frame = _simulate_prepared(config, net, y0)
+            metric_values = {metric.name: _metric_value(frame, metric) for metric in plan.metrics}
+        except Exception as exc:
+            raise RuntimeError(f"Sensitivity evaluation {sample_id} failed for parameters {values}: {exc}") from exc
+        non_finite = [name for name, value in metric_values.items() if not np.isfinite(value)]
+        if non_finite:
+            raise RuntimeError(
+                f"Sensitivity evaluation {sample_id} produced non-finite metrics {non_finite} for parameters {values}"
+            )
+        for name, value in metric_values.items():
+            responses[name].append(value)
+
+    index_rows = []
+    for metric in plan.metrics:
+        values = np.asarray(responses[metric.name], dtype=float)
+        if np.ptp(values) == 0:
+            raise ValueError(f"Sensitivity metric {metric.name!r} is constant at {values[0]}")
+        indices = sobol_analyze.analyze(
+            problem,
+            values,
+            calc_second_order=False,
+            num_resamples=_NUM_RESAMPLES,
+            conf_level=_CONF_LEVEL,
+            print_to_console=False,
+            parallel=False,
+            seed=plan.seed,
+        )
+        for index, parameter_name in enumerate(names):
+            estimates = {
+                "S1": float(indices["S1"][index]),
+                "S1_conf": float(indices["S1_conf"][index]),
+                "ST": float(indices["ST"][index]),
+                "ST_conf": float(indices["ST_conf"][index]),
+            }
+            if not all(np.isfinite(value) for value in estimates.values()):
+                raise ValueError(
+                    f"Sobol analysis produced non-finite indices for metric "
+                    f"{metric.name!r}, parameter {parameter_name!r}"
+                )
+            index_rows.append(
+                {
+                    "metric": metric.name,
+                    "parameter": parameter_name,
+                    **estimates,
+                }
+            )
+
+    samples_frame = pd.DataFrame(samples, columns=names)
+    samples_frame.insert(0, "sample_id", np.arange(len(samples), dtype=int))
+    responses_frame = pd.DataFrame(responses)
+    responses_frame.insert(0, "sample_id", np.arange(len(samples), dtype=int))
+    indices_frame = pd.DataFrame(index_rows)
+
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{plan.name}.", dir=parent))
+    try:
+        samples_frame.to_csv(temporary / "samples.csv", index=False, lineterminator="\n")
+        responses_frame.to_csv(temporary / "responses.csv", index=False, lineterminator="\n")
+        indices_frame.to_csv(temporary / "indices.csv", index=False, lineterminator="\n")
+        artifacts = {filename: {"sha256": _sha256(temporary / filename)} for filename in _ARTIFACT_NAMES}
+        manifest = {
+            "schema_version": 1,
+            "study_fingerprint": fingerprint,
+            "evaluation_count": plan.evaluation_count,
+            "request": request,
+            "source_config": {"path": str(source_path), "sha256": source_config_sha256},
+            "artifacts": artifacts,
+        }
+        (temporary / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        try:
+            temporary.rename(target)
+        except OSError:
+            if not target.exists():
+                raise
+            summary = _reuse_existing(target, fingerprint, plan.evaluation_count)
+            summary["elapsed_seconds"] = time.monotonic() - started
+            return summary
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+
+    return {
+        **_artifact_paths(target),
+        "reused": False,
+        "planned_evaluations": plan.evaluation_count,
+        "completed_evaluations": plan.evaluation_count,
+        "elapsed_seconds": time.monotonic() - started,
+    }

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -125,6 +125,10 @@ def test_sobol_study_writes_complete_deterministic_artifacts(tmp_path):
     assert manifest["evaluation_count"] == 128
     assert manifest["request"]["method"]["calc_second_order"] is False
     assert manifest["request"]["method"]["num_resamples"] == 100
+    assert manifest["request"]["normalized_config"]["Parameters"] == {
+        "theta": 0.1,
+        "unused": 1.0,
+    }
     assert set(manifest["artifacts"]) == {"samples.csv", "responses.csv", "indices.csv"}
 
 
@@ -241,11 +245,13 @@ def test_validate_and_sensitivity_cli_json(tmp_path):
         ["patchsim", "validate", "-c", str(config_path), "--json"],
         capture_output=True,
         text=True,
+        timeout=300,
     )
     result = subprocess.run(
         ["patchsim", "sensitivity", "-c", str(config_path), "--json"],
         capture_output=True,
         text=True,
+        timeout=300,
     )
 
     assert validation.returncode == 0, validation.stderr

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,266 @@
+import json
+import subprocess
+from copy import deepcopy
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+import patchsim
+import patchsim.sensitivity as sensitivity_module
+from patchsim.core.simulation import load_config
+from patchsim.sensitivity import get_sensitivity_plan, run_sensitivity
+
+
+def _write_project(tmp_path: Path, *, base_samples: int = 32) -> Path:
+    pd.DataFrame({"patch": ["A"], "population": [100.0]}).to_csv(tmp_path / "patches.csv", index=False)
+    pd.DataFrame({"patch": ["A"], "S": [0.0], "I": [100.0], "R": [0.0]}).to_csv(tmp_path / "seeds.csv", index=False)
+    config = {
+        "ModelName": "sensitivity-test",
+        "PatchFile": "patches.csv",
+        "SeedFile": "seeds.csv",
+        "NetworkFile": None,
+        "OutputDir": "output",
+        "TMax": 5,
+        "Solver": "discrete",
+        "TimeStep": 1.0,
+        "compartments": ["S", "I", "R"],
+        "Parameters": {"theta": 0.1, "unused": 1.0},
+        "Transitions": {"I -> R": "theta * I"},
+        "Sensitivity": {
+            "Name": "theta-study",
+            "Method": "sobol",
+            "BaseSamples": base_samples,
+            "Seed": 42,
+            "Parameters": {"theta": [0.01, 0.2], "unused": [1.0, 2.0]},
+            "Metrics": {
+                "final_r": {"Columns": ["R_0"], "Reduce": "final"},
+                "peak_r": {"Columns": ["R_0"], "Reduce": "max"},
+            },
+        },
+    }
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_simulate_is_side_effect_free_and_accepts_global_overrides(tmp_path):
+    config_path = _write_project(tmp_path)
+    config = load_config(str(config_path))
+    original = deepcopy(config)
+
+    baseline = patchsim.simulate(config)
+    changed = patchsim.simulate(config, parameter_overrides={"theta": 0.2})
+
+    assert config == original
+    assert not Path(config["OutputDir"]).exists()
+    assert baseline.columns.tolist() == ["time", "S_0", "I_0", "R_0"]
+    assert changed["R_0"].iloc[-1] > baseline["R_0"].iloc[-1]
+
+
+def test_simulate_rejects_unknown_non_finite_and_patch_specific_overrides(tmp_path):
+    config = load_config(str(_write_project(tmp_path)))
+
+    with pytest.raises(ValueError, match="Unknown global"):
+        patchsim.simulate(config, parameter_overrides={"missing": 1.0})
+    with pytest.raises(ValueError, match="finite real"):
+        patchsim.simulate(config, parameter_overrides={"theta": float("nan")})
+
+    config["PatchParameters"] = [{"patch": "A", "parameters": {"theta": 0.05}}]
+    with pytest.raises(ValueError, match="PatchParameters"):
+        patchsim.simulate(config, parameter_overrides={"theta": 0.1})
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("Name", "../escape", "safe path"),
+        ("BaseSamples", 1, "at least 2"),
+        ("BaseSamples", 12, "power of two"),
+        ("Seed", -1, "non-negative"),
+        ("Parameters", {"theta": [0.2, 0.1]}, "lower < upper"),
+    ],
+)
+def test_sensitivity_plan_rejects_invalid_contract(tmp_path, field, value, message):
+    config = load_config(str(_write_project(tmp_path)))
+    config["Sensitivity"][field] = value
+
+    with pytest.raises(ValueError, match=message):
+        get_sensitivity_plan(config, ["S_0", "I_0", "R_0"])
+
+
+def test_sensitivity_plan_rejects_ambiguous_or_unknown_columns(tmp_path):
+    config = load_config(str(_write_project(tmp_path)))
+    config["PatchParameters"] = [{"patch": "A", "parameters": {"theta": 0.05}}]
+    with pytest.raises(ValueError, match="PatchParameters"):
+        get_sensitivity_plan(config, ["S_0", "I_0", "R_0"])
+
+    config["PatchParameters"] = []
+    config["Sensitivity"]["Metrics"]["final_r"]["Columns"] = ["R_9"]
+    with pytest.raises(ValueError, match="unknown output"):
+        get_sensitivity_plan(config, ["S_0", "I_0", "R_0"])
+
+
+def test_sobol_study_writes_complete_deterministic_artifacts(tmp_path):
+    config_path = _write_project(tmp_path)
+
+    summary = run_sensitivity(config_path)
+
+    assert summary["reused"] is False
+    assert summary["planned_evaluations"] == summary["completed_evaluations"] == 128
+    samples = pd.read_csv(summary["samples_path"])
+    responses = pd.read_csv(summary["responses_path"])
+    indices = pd.read_csv(summary["indices_path"])
+    manifest = json.loads(Path(summary["manifest_path"]).read_text(encoding="utf-8"))
+
+    assert samples.columns.tolist() == ["sample_id", "theta", "unused"]
+    assert responses.columns.tolist() == ["sample_id", "final_r", "peak_r"]
+    assert len(samples) == len(responses) == 128
+    assert set(indices["metric"]) == {"final_r", "peak_r"}
+    final = indices.set_index(["metric", "parameter"]).loc["final_r"]
+    assert final.loc["theta", "ST"] > 0.95
+    assert abs(final.loc["unused", "ST"]) < 1e-12
+    assert manifest["evaluation_count"] == 128
+    assert manifest["request"]["method"]["calc_second_order"] is False
+    assert manifest["request"]["method"]["num_resamples"] == 100
+    assert set(manifest["artifacts"]) == {"samples.csv", "responses.csv", "indices.csv"}
+
+
+def test_identical_existing_study_is_reused_without_solves(tmp_path, monkeypatch):
+    config_path = _write_project(tmp_path, base_samples=8)
+    first = run_sensitivity(config_path)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("reused study must not run the model")
+
+    monkeypatch.setattr(sensitivity_module, "_simulate_prepared", fail_if_called)
+    second = run_sensitivity(config_path)
+
+    assert second["reused"] is True
+    assert second["completed_evaluations"] == 0
+    assert second["samples_path"] == first["samples_path"]
+
+
+@pytest.mark.parametrize("change", ["config", "artifact", "manifest"])
+def test_existing_study_rejects_changed_inputs_or_artifacts(tmp_path, change):
+    config_path = _write_project(tmp_path, base_samples=8)
+    summary = run_sensitivity(config_path)
+
+    if change == "config":
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        config["Sensitivity"]["Seed"] = 43
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+        message = "different study"
+    else:
+        if change == "artifact":
+            Path(summary["samples_path"]).write_text("modified\n", encoding="utf-8")
+            message = "missing or modified"
+        else:
+            manifest_path = Path(summary["manifest_path"])
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["evaluation_count"] = 1
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            message = "different study"
+
+    with pytest.raises(FileExistsError, match=message):
+        run_sensitivity(config_path)
+
+
+def test_sensitivity_rejects_output_symlink_escape(tmp_path):
+    config_path = _write_project(tmp_path, base_samples=8)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    output = tmp_path / "output"
+    output.mkdir()
+    (output / "sensitivity").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes OutputDir"):
+        run_sensitivity(config_path)
+    assert not list(outside.iterdir())
+
+
+def test_failed_or_constant_study_publishes_nothing(tmp_path, monkeypatch):
+    config_path = _write_project(tmp_path, base_samples=8)
+
+    def fail(*_args, **_kwargs):
+        raise ValueError("solver failed")
+
+    monkeypatch.setattr(sensitivity_module, "_simulate_prepared", fail)
+    with pytest.raises(RuntimeError, match=r"evaluation 0.*theta.*solver failed"):
+        run_sensitivity(config_path)
+    assert not (tmp_path / "output").exists()
+
+    monkeypatch.undo()
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["Sensitivity"]["Metrics"] = {"susceptible": {"Columns": ["S_0"], "Reduce": "final"}}
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    with pytest.raises(ValueError, match="constant at 0"):
+        run_sensitivity(config_path)
+    assert not (tmp_path / "output").exists()
+
+
+def test_multicolumn_metric_does_not_skip_non_finite_values(tmp_path, monkeypatch):
+    config_path = _write_project(tmp_path, base_samples=8)
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["Sensitivity"]["Metrics"] = {"combined": {"Columns": ["I_0", "R_0"], "Reduce": "final"}}
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    def non_finite(*_args, **_kwargs):
+        return pd.DataFrame({"time": [0.0], "S_0": [0.0], "I_0": [1.0], "R_0": [float("nan")]})
+
+    monkeypatch.setattr(sensitivity_module, "_simulate_prepared", non_finite)
+    with pytest.raises(RuntimeError, match="non-finite metrics.*combined"):
+        run_sensitivity(config_path)
+    assert not (tmp_path / "output").exists()
+
+
+def test_recomputation_is_byte_identical(tmp_path):
+    config_path = _write_project(tmp_path, base_samples=8)
+    first = run_sensitivity(config_path)
+    first_bytes = {
+        name: (Path(first["output_dir"]) / name).read_bytes()
+        for name in (*sensitivity_module._ARTIFACT_NAMES, "manifest.json")
+    }
+    target = Path(first["output_dir"])
+    for path in target.iterdir():
+        path.unlink()
+    target.rmdir()
+
+    second = run_sensitivity(config_path)
+
+    assert second["reused"] is False
+    for name, expected in first_bytes.items():
+        assert (Path(second["output_dir"]) / name).read_bytes() == expected
+
+
+def test_validate_and_sensitivity_cli_json(tmp_path):
+    config_path = _write_project(tmp_path, base_samples=8)
+    validation = subprocess.run(
+        ["patchsim", "validate", "-c", str(config_path), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    result = subprocess.run(
+        ["patchsim", "sensitivity", "-c", str(config_path), "--json"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert validation.returncode == 0, validation.stderr
+    assert json.loads(validation.stdout)["sensitivity"]["evaluation_count"] == 32
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["completed_evaluations"] == 32
+    assert Path(payload["indices_path"]).is_file()
+    assert "Planned model evaluations: 32" in result.stderr
+
+
+def test_salib_dependency_errors_are_actionable(monkeypatch):
+    def missing(_package):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(sensitivity_module, "version", missing)
+    with pytest.raises(RuntimeError, match=r"patchsim\[analysis\]"):
+        sensitivity_module._load_salib()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -18,6 +18,7 @@ def test_patchsim_sdk_exports():
     assert hasattr(patchsim, "load_config")
     assert hasattr(patchsim, "setup_simulation")
     assert hasattr(patchsim, "run_simulation")
+    assert hasattr(patchsim, "simulate")
     assert hasattr(patchsim, "plot_patch_subplots")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1769,12 +1769,14 @@ dependencies = [
     { name = "pandas" },
     { name = "pyyaml" },
     { name = "rich" },
-    { name = "salib" },
     { name = "scipy" },
     { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
+analysis = [
+    { name = "salib" },
+]
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
@@ -1836,14 +1838,14 @@ requires-dist = [
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'lint'" },
-    { name = "salib", specifier = ">=1.5" },
+    { name = "salib", marker = "extra == 'analysis'", specifier = ">=1.5.2" },
     { name = "scipy", specifier = ">=1.11" },
     { name = "seaborn", marker = "extra == 'notebook'" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=6.0" },
     { name = "tqdm", specifier = ">=4.66" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
 ]
-provides-extras = ["geo", "test", "docs", "lint", "dev", "notebook"]
+provides-extras = ["geo", "analysis", "test", "docs", "lint", "dev", "notebook"]
 
 [[package]]
 name = "pathspec"
@@ -2571,7 +2573,7 @@ wheels = [
 
 [[package]]
 name = "salib"
-version = "1.5.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
@@ -2580,9 +2582,9 @@ dependencies = [
     { name = "pandas" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/8c/3e09d6b40f90ccf04b1308a88b7bf496596704e01ca30782a524d025a0e1/salib-1.5.1.tar.gz", hash = "sha256:e4a9c319b8dd02995a8dc983f57c452cb7e5b6dbd43e7b7856c90cb6a332bb5f", size = 725018, upload-time = "2024-08-19T16:35:25.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/63/bdde6c303e95e2c819c668076fb3255f4453ee2041103d0edd18a90b6839/salib-1.5.2.tar.gz", hash = "sha256:a8eeedc4e87cf070f7ef450b76cdecd120d1e5c602a9c35855ec7777591f949f", size = 725859, upload-time = "2025-10-12T02:38:50.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/40/393b381779d379afbb0e281d9f69cb511022e41a726f7871a929faec2b11/salib-1.5.1-py3-none-any.whl", hash = "sha256:a978b619c5a93eb14dd8c527f12e22d354b02f1f7143aba3cb84c1c7bc1382e5", size = 778858, upload-time = "2024-08-19T16:35:23.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/9fbf2d571c0d5360f9cf6656de6c94b273d08ede1b628f23f319fa1a910d/salib-1.5.2-py3-none-any.whl", hash = "sha256:6f4b6bebc1eeed1d081c8f951fa8c2ad7b0cd8a7159d206af48ef137cc806c43", size = 780059, upload-time = "2025-10-12T02:38:48.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add side-effect-free `patchsim.simulate(...)` for in-memory model evaluation and external fitting workflows
- add optional SALib 1.5.2 Sobol analysis with validated independent-uniform bounds, scalar metrics, deterministic artifacts, and verified study reuse
- add `patchsim sensitivity`, configuration schema support, and one worked documentation workflow
- keep calibration, second-order indices, parallel execution, hidden caches, and callback loading out of scope

## Verification

- `uv run --frozen --extra analysis --extra lint ruff check .`
- `uv run --frozen --extra analysis --extra lint ruff format --check .`
- `uv run --frozen --extra analysis --extra test pytest -q` (153 passed)
- `uv run --frozen --extra docs sphinx-build -E -b html docs /tmp/patchsim-docs -W`
- generated two-patch SIR studies completed the exact planned counts at `N=64` (256 solves) and `N=128` (512 solves); an identical rerun reused verified artifacts with zero solves
- rendered workflow checked at desktop and mobile viewports with no page overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sobol sensitivity studies through the `patchsim sensitivity` command.
  * Added in-memory simulation through the public Python SDK, including parameter overrides.
  * Sensitivity results now include samples, responses, indices, and reproducibility manifests.
  * Added reuse of matching completed sensitivity studies and protection against overwriting changed or incomplete results.

* **Documentation**
  * Added configuration, workflow, CLI, architecture, and results guidance for sensitivity studies.
  * Clarified installation requirements and reproducibility practices.

* **Chores**
  * Made sensitivity-analysis dependencies optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->